### PR TITLE
Fix bug when deserializing V::Threshold

### DIFF
--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -1928,7 +1928,7 @@ pub fn parse_subexpression(tokens: &mut TokenIter) -> Result<Box<AstElem>, Error
         // vexpr [tfvq]expr AND
         if ret.is_t() || ret.is_f() || ret.is_v() || ret.is_q() {
             match tokens.peek() {
-                None | Some(&Token::If) | Some(&Token::NotIf) | Some(&Token::Else) => Ok(ret),
+                None | Some(&Token::If) | Some(&Token::NotIf) | Some(&Token::Else) | Some(&Token::ToAltStack) => Ok(ret),
                 _ => {
                     let left = parse_subexpression(tokens)?;
                     let left = if left.is_v() {

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -1696,14 +1696,26 @@ pub fn parse_subexpression(tokens: &mut TokenIter) -> Result<Box<AstElem>, Error
                 let mut ws = vec![];
                 let e;
                 loop {
-                    let next_sub = parse_subexpression(tokens)?;
-                    if next_sub.is_w() {
-                        ws.push(next_sub.into_w());
-                    } else if next_sub.is_e() {
-                        e = next_sub.into_e();
-                        break;
-                    } else {
-                        return Err(Error::Unexpected(next_sub.to_string()));
+                    match tokens.next() {
+                        Some(Token::Add) => {
+                            let next_sub = parse_subexpression(tokens)?;
+                            if next_sub.is_w() {
+                                ws.push(next_sub.into_w());
+                            } else {
+                                return Err(Error::Unexpected(next_sub.to_string()));
+                            }
+                        }
+                        Some(x) => {
+                            tokens.un_next(x);
+                            let next_sub = parse_subexpression(tokens)?;
+                            if next_sub.is_e() {
+                                e = next_sub.into_e();
+                                break;
+                            } else {
+                                return Err(Error::Unexpected(next_sub.to_string()));
+                            }
+                        }
+                        None => return Err(Error::UnexpectedStart)
                     }
                 }
                 Ok(Box::new(V::Threshold(k as usize, e, ws)))

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -126,6 +126,7 @@ pub fn lex(script: &script::Script) -> Result<Vec<Token>, Error> {
             script::Instruction::Op(opcodes::all::OP_TOALTSTACK) => Token::ToAltStack,
             script::Instruction::Op(opcodes::all::OP_DROP) => Token::Drop,
             script::Instruction::Op(opcodes::all::OP_DUP) => Token::Dup,
+            script::Instruction::Op(opcodes::all::OP_ADD) => Token::Add,
             script::Instruction::Op(opcodes::all::OP_IF) => Token::If,
             script::Instruction::Op(opcodes::all::OP_IFDUP) => Token::IfDup,
             script::Instruction::Op(opcodes::all::OP_NOTIF) => Token::NotIf,

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -330,6 +330,16 @@ mod tests {
                 OP_CHECKSIG OP_SWAP OP_PUSHBYTES_33 028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa \
                 OP_CHECKSIG OP_ADD OP_PUSHNUM_1 OP_EQUALVERIFY OP_PUSHNUM_1 OP_ELSE OP_0 OP_ENDIF)"
         );
+
+        roundtrip(
+            &Miniscript(
+                T::ParallelOr(
+                    Rc::new(E::Time(1)),
+                    Rc::new(W::CastE(Rc::new(E::Time(1)))))
+            ),
+            "Script(OP_DUP OP_IF OP_PUSHNUM_1 OP_NOP3 OP_DROP OP_ENDIF OP_TOALTSTACK OP_DUP OP_IF OP_PUSHNUM_1 OP_NOP3 OP_DROP OP_ENDIF OP_FROMALTSTACK OP_BOOLOR)"
+        );
+
     }
 
     #[test]

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -157,7 +157,7 @@ mod tests {
     use std::rc::Rc;
 
     use super::Miniscript;
-    use miniscript::astelem::{E, W, V, T};
+    use miniscript::astelem::{E, W, V, T, F};
 
     use bitcoin::blockdata::script;
     use bitcoin::util::key::PublicKey;
@@ -314,6 +314,21 @@ mod tests {
                 Rc::new(W::CheckSig(keys[0].clone())),
             )),
             "Script(OP_0 OP_0 OP_CHECKMULTISIG OP_SWAP OP_PUSHBYTES_33 028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa OP_CHECKSIG OP_BOOLOR)"
+        );
+
+        roundtrip(
+            &Miniscript(T::CastE(
+                E::Likely(
+                    Rc::new(F::Threshold(
+                        1,
+                        Rc::new(E::CheckSig(keys[0].clone())),
+                        vec![Rc::new(W::CheckSig(keys[0].clone()))]
+                    ))
+                )
+            )),
+            "Script(OP_NOTIF OP_PUSHBYTES_33 028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa \
+                OP_CHECKSIG OP_SWAP OP_PUSHBYTES_33 028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa \
+                OP_CHECKSIG OP_ADD OP_PUSHNUM_1 OP_EQUALVERIFY OP_PUSHNUM_1 OP_ELSE OP_0 OP_ENDIF)"
         );
     }
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -340,6 +340,21 @@ mod tests {
             "Script(OP_DUP OP_IF OP_PUSHNUM_1 OP_NOP3 OP_DROP OP_ENDIF OP_TOALTSTACK OP_DUP OP_IF OP_PUSHNUM_1 OP_NOP3 OP_DROP OP_ENDIF OP_FROMALTSTACK OP_BOOLOR)"
         );
 
+        roundtrip(
+            &Miniscript(
+                T::And(
+                    Rc::new(V::Time(1)),
+                    Rc::new(T::CastE(E::Threshold(
+                        1,
+                        Rc::new(E::Time(3)),
+                        vec![Rc::new(W::Time(4))]
+                    )))
+                )
+            ),
+            "Script(OP_PUSHNUM_1 OP_NOP3 OP_DROP OP_DUP OP_IF OP_PUSHNUM_3 OP_NOP3 \
+                 OP_DROP OP_ENDIF OP_SWAP OP_DUP OP_IF OP_PUSHNUM_4 OP_NOP3 OP_DROP \
+                  OP_ENDIF OP_ADD OP_PUSHNUM_1 OP_EQUAL)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
While I was porting this library in to F#, I think I found a bug.

`V::Threshold` and `E::Threshold` has almost same representation in script, but `V::Threshold` did not deserialize properly. I suppose this PR will fix.

Tell me if I'm misunderstanding something.