### PR TITLE
Fixed max satisfaction size calculation bug for PK case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 repository = "https://github.com/apoelstra/miniscript"
 description = "Miniscript: a subset of Bitcoin Script designed for analysis"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //!     );
 //!
 //!     // Estimate the satisfaction cost
-//!     assert_eq!(desc.max_satisfaction_weight(), 256);
+//!     assert_eq!(desc.max_satisfaction_weight(), 293);
 //! }
 //! ```
 //!

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -1165,10 +1165,10 @@ impl<P: ToPublicKey> AstElem<P> {
     /// at parse time. Any exceptions are bugs.)
     pub fn max_satisfaction_size(&self, one_cost: usize) -> usize {
         match *self {
-            AstElem::Pk(ref p) |
-            AstElem::PkV(ref p) |
-            AstElem::PkQ(ref p) |
-            AstElem::PkW(ref p) => pubkey_size(p) + 2,
+            AstElem::Pk(..) |
+            AstElem::PkV(..) |
+            AstElem::PkQ(..) |
+            AstElem::PkW(..) => 73,
             AstElem::Multi(k, _) |
             AstElem::MultiV(k, _) => 1 + 73 * k,
             AstElem::TimeT(..) |


### PR DESCRIPTION
From #6 
I think the witness for pubkey should be 73 bytes signature instead of pubkey_size(p) + 2. Or am I missing something?

Could not get #6 to reopen because I deleted the branch locally and remotely. 