### PR TITLE
Added interpreter for miniscript

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "0.5.7"
+version = "0.5.8"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 repository = "https://github.com/apoelstra/miniscript"
 description = "Miniscript: a subset of Bitcoin Script designed for analysis"

--- a/src/descriptor/create_descriptor.rs
+++ b/src/descriptor/create_descriptor.rs
@@ -1,0 +1,410 @@
+//! Tools for creating Descriptor and witness stack from given scriptpubkey and corresponding
+//! scriptsig and witness.
+//!
+
+use bitcoin::{self, Script, PublicKey};
+
+use descriptor::Descriptor;
+use miniscript::Miniscript;
+use miniscript::evaluate::StackElement;
+use Error;
+use ToPublicKey;
+use bitcoin::blockdata::script::Instruction;
+use bitcoin::blockdata::opcodes;
+
+/// Helper function for creating StackElement from Push instructions. Special case required for
+/// handling OP_PUSHNUM_1.
+/// Dissatisfied is Pushbytes0 and witness are mapped to Pushbytes instruction in scriptsig and
+/// satisfied is mapped as OP_PUSHNUM_1.
+/// Other opcodes are considered Non-standard in bitcoin core.
+/// Miniscript should not use other pushes apart from PUSHNUM_1. This will err on reciving anything
+/// which is not PUSHBYTES, OR PUSHNUM_1 as other things are expected to happen in Miniscript
+///
+/// NOTE: Miniscript pushes should only be either boolean, 1 or 0, signatures, and hash preimages.
+/// As per the current implementation, PUSH_NUM2 results in an error
+fn instr_to_stackelem(ins: Instruction) -> Result< StackElement, Error> {
+    match ins {
+        //Also covers the dissatisfied case as PushBytes0
+        Instruction::PushBytes(v) => Ok(StackElement::from(v.to_vec())),
+        Instruction::Op(opcodes::all::OP_PUSHNUM_1) => Ok(StackElement::Satisfied),
+        _ => Err(Error::BadDescriptor),
+    }
+}
+
+/// Helper function which splits the scriptsig into 2 parts returns the corresponding elements.
+/// Usually used for scripts which have top element as Pk (p2pkh) or redeem script(p2sh).
+/// Converts the other script elements into Vec<StackElement>
+fn parse_scriptsig_top(script_sig: &bitcoin::Script) -> Result<(Vec<u8>, Vec<StackElement>), Error>
+{
+    let instructions : Vec<Instruction> = script_sig.iter(false).collect();
+    let (pk_bytes, witness) = instructions.split_last().expect("public key/Redeem script");
+
+    let stack: Result< Vec<StackElement>, Error> = witness
+        .iter()
+        .map(|instr| instr_to_stackelem(instr.clone()))
+        .collect();
+
+    if let &Instruction::PushBytes(ref top) = pk_bytes {
+        Ok((top.to_vec(), stack?))
+    }
+    else {
+        Err(Error::BadDescriptor)
+    }
+}
+
+/// Helper to create a wpkh descriptor based on script_pubkey and witness. Validates the pubkey hash
+/// and pushes rest of witness to Vec<StackElement> as is.
+/// This does not check the signature, only creates the corresponding descriptor
+fn verify_wpkh(
+    script_pubkey: &bitcoin::Script,
+    script_sig: &bitcoin::Script,
+    witness: Vec<Vec<u8>>,
+) -> Result<(PublicKey, Vec<StackElement>), Error>
+{
+    //script_sig must be empty
+    if *script_sig != Script::new(){
+        return Err(Error::CouldnotEvaluate)
+    }
+    let (pk_bytes, witness) = witness.split_last().expect("Public key");
+    let pk = bitcoin::PublicKey::from_slice(pk_bytes).expect("Public key parse");
+    let addr = bitcoin::Address::p2wpkh(
+        &pk.to_public_key(),
+        bitcoin::Network::Bitcoin,
+    );
+    if addr.script_pubkey() != *script_pubkey{
+        return Err(Error::CouldnotEvaluate)
+    }
+    let stack : Vec<StackElement> = witness.iter()
+        .map(|elem| StackElement::from(elem.clone())).collect();
+    Ok((pk, stack))
+}
+
+/// Helper for creating a wsh descriptor based on script_pubkey and witness. Validates the wsh
+/// hash based on witness script, pops the witness script from the stack and returns
+/// witness Vec<StackElement>. Does not interpret/check the witness against the miniscript inside
+/// the descriptor
+fn verify_wsh(
+    script_pubkey: &bitcoin::Script,
+    script_sig: &bitcoin::Script,
+    witness: Vec<Vec<u8>>,
+) -> Result<(Miniscript<PublicKey>, Vec<StackElement>), Error>
+{
+    if *script_sig != Script::new(){
+        return Err(Error::BadDescriptor)
+    }
+    let (witness_script, witness) = witness.split_last().expect("Public key");
+    let witness_script = Script::from(witness_script.clone());
+    if witness_script.to_v0_p2wsh() != *script_pubkey{
+        return Err(Error::BadDescriptor)
+    }
+    let ms = Miniscript::parse(&witness_script)?;
+    //only iter till len -1 to not include the witness script
+    let stack : Vec<StackElement> = witness.iter()
+        .map(|elem| StackElement::from(elem.clone())).collect();
+    Ok((ms, stack))
+}
+
+
+/// Creates a pkh descriptor based on scriptsig and script_pubkey. Validates the hash checks for
+/// p2pkh against top element(pk) and pushes all remaining witness elements into witness<StackElement>
+fn verify_p2pkh(
+    script_pubkey: &bitcoin::Script,
+    script_sig: &bitcoin::Script,
+    witness: Vec<Vec<u8>>,
+) -> Result<(Descriptor<PublicKey>, Vec<StackElement>), Error>
+{
+    let (pk_bytes, stack) = parse_scriptsig_top(script_sig)?;
+    let pk = bitcoin::PublicKey::from_slice(&pk_bytes).expect("Public key parse");
+    let addr = bitcoin::Address::p2pkh(
+        &pk.to_public_key(),
+        bitcoin::Network::Bitcoin,
+    );
+    if *script_pubkey != addr.script_pubkey() || witness.len() != 0{
+        return Err(Error::BadDescriptor)
+    }
+    Ok((Descriptor::Pkh(pk), stack))
+}
+
+/// Helper for creating a p2sh descriptor based on script_pubkey and witness. Validates the p2sh
+/// hash based on redeem script, pops the redeem script from the script sig stack, translates other
+/// elements from scriptsig into Vec<StackElement>
+fn verify_p2sh(
+    script_pubkey: &bitcoin::Script,
+    script_sig: &bitcoin::Script,
+) -> Result<(Script, Vec<StackElement>), Error>
+{
+    let (redeem_script, stack) = parse_scriptsig_top(script_sig)?;
+    let redeem_script = Script::from(redeem_script);
+    if redeem_script.to_p2sh() != *script_pubkey {
+        return Err(Error::BadDescriptor)
+    }
+    Ok((redeem_script, stack))
+}
+
+/// Figures out the the type of descriptor based on scriptpubkey, witness and scriptsig.
+/// Outputs a descriptor and witness_stack for all descriptors which can be directly fed into the
+/// interpreter. All script_sig and witness are translated into a single witness stack
+/// Vec<StackElement>
+/// 1) Pkh: Removes top element(pk) and validates pubkey hash, pushes rest of witness to
+/// witness_stack<StackElement> and outputs a Pkh descriptor
+/// 2) Wphk: translates witness to witness_stack<StackElement>, validates sig and pubkey hash
+/// and outputs a Wpkh descriptor
+/// 3) Wsh: pops witness script and checks wsh output hash, translates remaining witness elements
+/// to Vec<StackElement> and outputs a Wsh descriptor. Does not check miniscript inside the descriptor
+/// 4) Bare: translates script_sig to witness_stack<StackElement> and script_pubkey to miniscript
+/// 5) Sh: Checks redeem_script hash, translates remaining elements from script_sig to
+/// witness_stack<StackElement> and redeem script to miniscript. Does not check the miniscript
+/// 6) ShWpkh: Sh: Checks redeem_script hash, translates remaining elements from script_sig to
+/// witness_stack<StackElement> and validates Wpkh sig, pubkey.
+/// 7) ShWsh: Checks witness script hash, pops witness script and converts it to miniscript.
+/// translates the remaining witness to witness_stack<StackElement>
+pub fn witness_stack(
+    script_pubkey: &bitcoin::Script,
+    script_sig: &bitcoin::Script,
+    witness: Vec<Vec<u8>>,
+) -> Result<(Descriptor<PublicKey>, Vec<StackElement>), Error>
+{
+    if script_pubkey.is_p2pkh(){
+        verify_p2pkh(script_pubkey, script_sig, witness)
+    }
+    else if script_pubkey.is_v0_p2wpkh(){
+        let (pk, stack) = verify_wpkh(script_pubkey, script_sig, witness)?;
+        Ok((Descriptor::Wpkh(pk), stack))
+    }
+    else if script_pubkey.is_v0_p2wsh(){
+        let (ms, stack) = verify_wsh(script_pubkey, script_sig, witness)?;
+        Ok((Descriptor::Wsh(ms), stack))
+    }
+    else if script_pubkey.is_p2sh(){
+        let (redeem_script, stack) = verify_p2sh(script_pubkey, script_sig)?;
+        if redeem_script.is_v0_p2wpkh()
+        {
+            //ensures that scriptsig after popping redeem script contains 0 elements.
+            //Therefore while calling verify_wpkh, an argument of Script::new() is passed instead
+            //of script_sig. The redeem_script becomes the script_pubkey
+            if stack.len() != 0{
+                return Err(Error::BadDescriptor)
+            }
+            let (pk, stack) = verify_wpkh(&redeem_script, &Script::new(), witness)?;
+            Ok((Descriptor::ShWpkh(pk), stack))
+        }else if redeem_script.is_v0_p2wsh() {
+            //ensures that scriptsig after popping redeem script contains 0 elements.
+            //Therefore while calling verify_wpkh, an argument of Script::new() is passed instead
+            //of script_sig. The redeem_script becomes the script_pubkey
+            if stack.len() != 0{
+                return Err(Error::BadDescriptor)
+            }
+            let (ms, stack) = verify_wsh(&redeem_script, &Script::new(), witness)?;
+            Ok((Descriptor::ShWsh(ms), stack))
+        }
+        else{
+            if witness.len() != 0{
+                return Err(Error::BadDescriptor)
+            }
+            let ms = Miniscript::parse(&redeem_script)?;
+            Ok((Descriptor::Sh(ms), stack))
+        }
+    }
+    else{
+        //bare
+        let stack : Result <Vec<StackElement>, Error> = script_sig
+            .iter(false)
+            .map(|instr| instr_to_stackelem(instr.clone()))
+            .collect();
+        if witness.len() != 0{
+            return Err(Error::BadDescriptor)
+        }
+        let ms = Miniscript::parse(script_pubkey)?;
+        Ok((Descriptor::Bare(ms), stack?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ::{Descriptor, Miniscript};
+    use descriptor::create_descriptor::witness_stack;
+    use bitcoin::blockdata::script;
+    use bitcoin::{self, PublicKey};
+    use secp256k1::{self, Secp256k1, VerifyOnly};
+    use miniscript::evaluate::StackElement;
+    use miniscript::astelem::AstElem;
+
+    fn setup_keys_sigs(n: usize)
+                       -> ( Vec<PublicKey>, Vec<Vec<u8> >, secp256k1::Message, Secp256k1<VerifyOnly>) {
+        let secp_sign = secp256k1::Secp256k1::signing_only();
+        let secp_verify = secp256k1::Secp256k1::verification_only();
+        let msg = secp256k1::Message::from_slice(
+            &b"Yoda: btc, I trust. HODL I must!"[..]
+        ).expect("32 bytes");
+        let mut pks = vec![];
+        let mut sigs = vec![];
+        let mut sk = [0; 32];
+        for i in 1..n+1 {
+            sk[0] = i as u8;
+            sk[1] = (i >> 8) as u8;
+            sk[2] = (i >> 16) as u8;
+
+            let sk = secp256k1::SecretKey::from_slice(&sk[..]).expect("secret key");
+            let pk = PublicKey {
+                key: secp256k1::PublicKey::from_secret_key(
+                    &secp_sign,
+                    &sk,
+                ),
+                compressed: true,
+            };
+            let sig = secp_sign.sign(&msg, &sk);
+            let mut sigser = sig.serialize_der();
+            sigser.push(0x01); // sighash_all
+            pks.push(pk);
+            sigs.push(sigser);
+        }
+        (pks, sigs, msg, secp_verify)
+    }
+
+    #[test]
+    fn create_witness_stack(){
+        let (pks,sigs, _, _) = setup_keys_sigs(10);
+
+        //test pkh
+        let script_pubkey =  bitcoin::Address::p2pkh(
+            &pks[0],
+            bitcoin::Network::Bitcoin,
+        ).script_pubkey();
+        let script_sig = script::Builder::new()
+            .push_slice(&sigs[0])
+            .push_key(&pks[0])
+            .into_script();
+        let witness = vec![] as Vec<Vec<u8>>;
+        let (des, stack) = witness_stack(
+            &script_pubkey,
+            &script_sig,
+            witness,
+        ).expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(Descriptor::Pkh(pks[0]), des);
+        assert_eq!(stack,
+                   vec![StackElement::Witness(sigs[0].clone())]);
+
+        //test wpkh
+        let script_pubkey =  bitcoin::Address::p2wpkh(
+            &pks[1],
+            bitcoin::Network::Bitcoin,
+        ).script_pubkey();
+        let script_sig = script::Builder::new().into_script();
+        let witness = vec![sigs[1].clone(), pks[1].clone().to_bytes()];
+        let (des, stack) = witness_stack(
+            &script_pubkey,
+            &script_sig,
+            witness,
+        ).expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(Descriptor::Wpkh(pks[1]), des);
+        assert_eq!(stack, vec![StackElement::Witness(sigs[1].clone())]);
+
+        //test Wsh: and(pkv, pk). Note this does not check miniscript.
+        let ms = Miniscript(AstElem::AndCat(
+            Box::new(AstElem::PkV(pks[0].clone())),
+            Box::new(AstElem::Pk(pks[1].clone()))));
+        let script_pubkey =  bitcoin::Address::p2wsh(
+            &ms.encode(),
+            bitcoin::Network::Bitcoin,
+        ).script_pubkey();
+        let script_sig = script::Builder::new().into_script();
+        let witness = vec![sigs[1].clone(), sigs[0].clone(), ms.encode().to_bytes()];
+        let (des, stack) = witness_stack(
+            &script_pubkey,
+            &script_sig,
+            witness,
+        ).expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(Descriptor::Wsh(ms.clone()), des);
+        assert_eq!(stack,
+                   vec![StackElement::Witness(sigs[1].clone()),
+                        StackElement::Witness(sigs[0].clone())]);
+
+        //test Bare: and(pkv, pk). Note this does not check miniscript.
+        let ms = Miniscript(AstElem::OrBool(
+            Box::new(AstElem::Pk(pks[0].clone())),
+            Box::new(AstElem::PkW(pks[1].clone()))));
+        let script_pubkey =  ms.encode();
+        let script_sig = script::Builder::new()
+            .push_int(0)
+            .push_slice(&sigs[0])
+            .into_script();
+        let witness = vec![] as Vec<Vec<u8>>;
+        let (des, stack) = witness_stack(
+            &script_pubkey,
+            &script_sig,
+            witness,
+        ).expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(Descriptor::Bare(ms.clone()), des);
+        assert_eq!(stack,
+                   vec![StackElement::Dissatisfied,
+                        StackElement::Witness(sigs[0].clone())]);
+
+        //test Sh: and(pkv, pk). Note this does not check miniscript.
+        let ms = Miniscript(AstElem::OrKey(
+            Box::new(AstElem::PkQ(pks[0].clone())),
+            Box::new(AstElem::PkQ(pks[1].clone()))));
+        let script_pubkey =  bitcoin::Address::p2sh(
+            &ms.encode(),
+            bitcoin::Network::Bitcoin,
+        ).script_pubkey();
+        let script_sig = script::Builder::new()
+            .push_slice(&sigs[0])
+            .push_int(1)
+            .push_slice(&ms.encode().to_bytes())
+            .into_script();
+        let witness = vec![] as Vec<Vec<u8>>;
+        let (des, stack) = witness_stack(
+            &script_pubkey,
+            &script_sig,
+            witness,
+        ).expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(Descriptor::Sh(ms.clone()), des);
+        assert_eq!(stack,
+                   vec![StackElement::Witness(sigs[0].clone()),
+                        StackElement::Satisfied]);
+
+        //test Shwsh: and(pkv, pk). Note this does not check miniscript.
+        //Check with incorrect witness
+        let ms = Miniscript(AstElem::AndCat(
+            Box::new(AstElem::PkV(pks[0].clone())),
+            Box::new(AstElem::Pk(pks[1].clone()))));
+        let script_pubkey =  bitcoin::Address::p2shwsh(
+            &ms.encode(),
+            bitcoin::Network::Bitcoin,
+        ).script_pubkey();
+        let script_sig = script::Builder::new()
+            .push_slice(&ms.encode().to_v0_p2wsh().to_bytes())
+            .into_script();
+        let witness = vec![sigs[1].clone(), sigs[3].clone(), ms.encode().to_bytes()];
+        let (des, stack) = witness_stack(
+            &script_pubkey,
+            &script_sig,
+            witness,
+        ).expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(Descriptor::ShWsh(ms.clone()), des);
+        assert_eq!(stack,
+                   vec![StackElement::Witness(sigs[1].clone()),
+                        StackElement::Witness(sigs[3].clone())]);
+
+        //test wpkh
+        let script_pubkey =  bitcoin::Address::p2shwpkh(
+            &pks[2],
+            bitcoin::Network::Bitcoin,
+        ).script_pubkey();
+        let redeem_script =  bitcoin::Address::p2wpkh(
+            &pks[2],
+            bitcoin::Network::Bitcoin,
+        ).script_pubkey();
+        let script_sig = script::Builder::new()
+            .push_slice(&redeem_script.to_bytes())
+            .into_script();
+        let witness = vec![sigs[2].clone(), pks[2].clone().to_bytes()];
+        let (des, stack) = witness_stack(
+            &script_pubkey,
+            &script_sig,
+            witness,
+        ).expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(Descriptor::ShWpkh(pks[2]), des);
+        assert_eq!(stack, vec![StackElement::Witness(sigs[2].clone())]);
+    }
+}

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -39,6 +39,8 @@ use pubkey_size;
 use ToPublicKey;
 use secp256k1::VerifyOnly;
 
+mod create_descriptor;
+pub use self::create_descriptor::witness_stack;
 
 /// Script descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,10 +171,18 @@ pub enum Error {
     MissingHash(sha256::Hash),
     /// Could not satisfy a script (fragment) because of a missing signature
     MissingSig(bitcoin::PublicKey),
+    /// Could not evaluate a script (fragment) because of error in script execution
+    CouldnotEvaluate,
     /// Could not satisfy, locktime not met
     LocktimeNotMet(u32),
     /// General failure to satisfy
-    CouldNotSatisfy
+    CouldNotSatisfy,
+    /// Could not evaluate a script (fragment) because of a invalid signature
+    VerifySigFail(bitcoin::PublicKey, secp256k1::Signature, secp256k1::Message),
+    /// Could not evaluate a script (fragment) because of a invalid hashlock
+    VerifyHashFail(sha256::Hash, Vec<u8>),
+    ///General error in creating descriptor
+    BadDescriptor
 }
 
 fn errstr(s: &str) -> Error {
@@ -208,9 +216,15 @@ impl fmt::Display for Error {
             Error::Unexpected(ref s) => write!(f, "unexpected «{}»", s),
             Error::MissingHash(ref h) => write!(f, "missing preimage of hash {}", h),
             Error::MissingSig(ref pk) => write!(f, "missing signature for key {:?}", pk),
+            Error::CouldnotEvaluate => f.write_str("Script execution/ miniscirpt interpretation error"),
             Error::LocktimeNotMet(n) => write!(f, "required locktime of {} blocks, not met", n),
             Error::CouldNotSatisfy => f.write_str("could not satisfy"),
             Error::BadPubkey(ref e) => fmt::Display::fmt(e, f),
+            Error::VerifySigFail(ref pk, ref sig, ref msg) =>
+                write!(f, "signature verification failed for key {:?}, sig {:?}, msg {:?}", pk, sig, msg),
+            Error::VerifyHashFail(ref h, ref preimage) =>
+                write!(f, "invalid hashlock, hash {}, preimage {:?}", h, preimage),
+            Error::BadDescriptor => f.write_str("could not create a descriptor"),
         }
     }
 }

--- a/src/miniscript/evaluate.rs
+++ b/src/miniscript/evaluate.rs
@@ -1,0 +1,606 @@
+//! # Interpreatation of Miniscript scripts
+//!
+//! Traits and implementations to support for interpretation of miniscripts.
+//!
+//!
+use bitcoin_hashes::sha256;
+use secp256k1;
+
+use Error;
+use miniscript::astelem::AstElem;
+use ToPublicKey;
+use secp256k1::{Secp256k1, Signature, VerifyOnly};
+use bitcoin_hashes::Hash;
+use bitcoin;
+
+///Primitives for Miniscript: a vector of public keys(sigs), hashlocks and timelocks
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct Primitives{
+    pub pks: Vec<bitcoin::PublicKey>,
+    pub hashlocks : Vec<Vec<u8>>,
+    pub timelocks : Vec<u32>
+}
+
+impl Primitives
+{
+    fn join(&mut self, other: &Primitives){
+        self.pks.extend(other.pks.clone());
+        self.hashlocks.extend(other.hashlocks.clone());
+        self.timelocks.extend(other.timelocks.clone());
+    }
+}
+
+
+/// Definition of Stack Element of the Witness stack used for interpretation of Miniscript.
+/// All stack elements with vec![] go to Dissatisfied and vec![1] are marked to Satisfied.
+/// Others are directly pushed as witness
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum StackElement {
+    /// Result of a satisfied E/T/W/F
+    Satisfied,
+    /// Result of a dissatisfied E/W
+    Dissatisfied,
+    /// Input from the witness stack
+    Witness(Vec<u8>),
+}
+
+impl From<Vec<u8>> for StackElement {
+    fn from(v: Vec<u8>) -> StackElement {
+        match v{
+            _ if v == vec![1] => StackElement::Satisfied,
+            _ if v == vec![] => StackElement::Dissatisfied,
+            _ => StackElement::Witness(v)
+        }
+    }
+}
+
+impl StackElement{
+
+    pub fn is_witness_or_err(self) -> Result<Vec<u8>, Error>
+    {
+        match self{
+            StackElement::Witness(v) => Ok(v),
+            _ => Err(Error::CouldnotEvaluate)
+        }
+    }
+}
+
+/// Trait describing an AST element which can be evaluated /interpreted , given an input witness and
+/// maps from the public data to corresponding witness data.
+pub trait Interpretable<P> {
+    /// Attempt to interpret a miniscript for a given witness and
+    fn interpret(
+        &self,
+        secp: &Secp256k1<VerifyOnly>,
+        stack: &mut Vec<StackElement>,
+        sighash: &secp256k1::Message,
+        age: u32,
+    ) -> Result<Primitives, Error>
+    where P : ToPublicKey + Clone;
+}
+
+impl <P: ToPublicKey + Clone> Interpretable<P> for AstElem<P> {
+    fn interpret(
+        &self,
+        secp: &Secp256k1<VerifyOnly>,
+        stack: &mut Vec<StackElement>,
+        sighash: &secp256k1::Message,
+        age: u32,
+    ) -> Result<Primitives, Error>
+    {
+        match *self {
+            AstElem::True => {
+                stack.push(StackElement::Satisfied);
+                Ok(Primitives{pks: vec![], hashlocks: vec![], timelocks: vec![]})
+            }
+            AstElem::Pk(ref p) => evaluate_pk(secp, stack, sighash, p),
+            AstElem::PkV(ref p) => {
+                let res = evaluate_pk(secp, stack, sighash, p)?;
+                evaluate_verify(stack)?;
+                Ok(res)
+            }
+            AstElem::PkQ(ref p) => {
+                stack.push(StackElement::Witness(p.to_public_key().to_bytes()));
+                Ok(Primitives{pks: vec![], hashlocks: vec![], timelocks: vec![]})
+            }
+            AstElem::PkW(ref p) => {
+                let witnesslen = stack.len();
+                stack.swap(witnesslen-1, witnesslen -2);//swap the last elements
+                evaluate_pk(secp, stack, sighash, p)
+            }
+            AstElem::Multi(k, ref keys) => evaluate_multi(secp, stack, sighash, k, keys),
+            AstElem::MultiV(k, ref keys) => {
+                let res = evaluate_multi(secp, stack, sighash, k, keys)?;
+                evaluate_verify(stack)?;
+                Ok(res)
+            }
+            AstElem::Time(t) => {
+                let res = evaluate_csv(age, t)?;
+                //Ideally should be: build_scriptint(t as i64)). But since this is a T value
+                //and it will never be popped, it is safe to push Satisfied.
+                stack.push(StackElement::Satisfied);
+                Ok(res)
+            }
+            AstElem::TimeV(t) =>  evaluate_csv(age, t),
+            AstElem::TimeF(t) => {
+                let res = evaluate_csv(age, t)?;
+                stack.push(StackElement::Satisfied);
+                Ok(res)
+            }
+            AstElem::TimeE(t) => evaluate_time_e(stack, age, t),
+            AstElem::TimeW(t) => {
+                let witnesslen = stack.len();
+                stack.swap(witnesslen-1, witnesslen -2);//swap the last elements
+                evaluate_time_e(stack, age, t)
+            }
+            AstElem::Hash(h) => evaluate_hash_t(stack, h),
+            AstElem::HashV(h) => {
+                let res = evaluate_hash_t(stack, h)?;
+                evaluate_verify(stack)?;
+                Ok(res)
+            }
+            AstElem::HashW(h) => evaluate_hash_w(stack, h),
+            AstElem::Wrap(ref sub) => {
+                let top = stack.pop().expect("Witness stack has at least one element");
+                let res = sub.interpret(secp, stack, sighash, age)?;
+                stack.push(top);
+                Ok(res)
+            }
+            AstElem::Likely(ref sub) => {
+                let top = stack.pop().expect("Witness stack has at least one element");
+                match top{
+                    StackElement::Satisfied => Ok(Primitives{pks: vec![], hashlocks: vec![], timelocks: vec![]}),
+                    StackElement::Dissatisfied => sub.interpret(secp, stack, sighash, age),
+                    _ =>  Err(Error::CouldnotEvaluate)
+                }
+            },
+            AstElem::Unlikely(ref sub) => {
+                let top = stack.pop().expect("Witness stack has at least one element");
+                match top{
+                    StackElement::Dissatisfied => Ok(Primitives{pks: vec![], hashlocks: vec![], timelocks: vec![]}),
+                    StackElement::Satisfied => sub.interpret(secp, stack, sighash, age),
+                    _ =>  Err(Error::CouldnotEvaluate)
+                }
+            },
+            AstElem::AndCat(ref left, ref right) => {
+                let mut res = left.interpret(secp, stack, sighash, age)?;
+                res.join(&right.interpret(secp, stack, sighash, age)?);
+                Ok(res)
+            }
+            AstElem::AndBool(ref left, ref right) => interpret_and_bool(secp, stack, sighash, age, left, right),
+            AstElem::AndCasc(ref left, ref right) => interpret_and_casc(secp, stack, sighash, age, left, right),
+            AstElem::OrBool(ref left, ref right) => interpret_or_bool(secp, stack, sighash, age, left, right),
+            AstElem::OrCasc(ref left, ref right) |
+            AstElem::OrCont(ref left, ref right) => interpret_or_casc(secp, stack, sighash, age, left, right),
+            AstElem::OrKey(ref left, ref right) => interpret_or_key(secp, stack, sighash, age, left, right),
+            AstElem::OrKeyV(ref left, ref right) => {
+                let res = interpret_or_key(secp, stack, sighash, age, left, right)?;
+                evaluate_verify(stack)?;
+                Ok(res)
+            }
+            AstElem::OrIf(ref left, ref right) =>  interpret_or_if(secp, stack, sighash, age, left, right),
+            AstElem::OrIfV(ref left, ref right) => {
+                let res = interpret_or_if(secp, stack, sighash, age, left, right)?;
+                evaluate_verify(stack)?;
+                Ok(res)
+
+            }
+            AstElem::OrNotif(ref left, ref right) => interpret_or_if(secp, stack, sighash, age, right, left),
+            AstElem::Thresh(k, ref subs) => evaluate_thres(secp, stack, sighash,age, k, subs),
+            AstElem::ThreshV(k, ref subs) => {
+                let res = evaluate_thres(secp, stack, sighash,age, k, subs)?;
+                evaluate_verify(stack)?;
+                Ok(res)
+            }
+        }
+    }
+
+}
+
+/// This functions is equivalent to VERIFY. This pops the top element and checks if it is non-zero.
+/// Gives an error in all other cases
+fn evaluate_verify(stack: &mut Vec<StackElement>) -> Result<(), Error>{
+    let top = stack.pop().expect("Non-zero element for verify");
+    match top {
+        StackElement::Dissatisfied => Err(Error::CouldnotEvaluate),
+        _ => Ok(())
+    }
+}
+
+/// Helper function to verify serialized signature
+pub fn verify_sersig(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    sighash: &secp256k1::Message,
+    pk: &bitcoin::PublicKey,
+    sigser: &Vec<u8>,
+) -> Result<(), Error>
+{
+    let mut sig = sigser.clone();
+    sig.pop().expect("SighashType: One byte");
+    let sig = Signature::from_der(&sig).expect("Signature parse");
+    let res = secp.verify(&sighash, &sig, &pk.key);
+
+    match res{
+        Ok(()) => Ok(()),
+        Err(..) => Err(Error::VerifySigFail(pk.clone(), sig, sighash.clone()))
+    }
+}
+
+
+/// Helper function to evaluate a Pk Node which takes the top of the stack as input
+/// signature and validates it.
+/// Sat: If the signature witness is correct, 1 is pushed
+/// Unsat: For empty witness a 0 is pushed
+/// Err: All of other witness result in errors.
+fn evaluate_pk<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    pk: &P,
+) -> Result<Primitives, Error>
+    where P: ToPublicKey + Clone,
+{
+    let sigser = stack.pop().expect("Witness stack has at least one element");
+
+    match sigser{
+        StackElement::Dissatisfied => {
+                stack.push(StackElement::Dissatisfied);
+                Ok(Primitives {pks: vec![], hashlocks: vec![],timelocks: vec![]})
+        },
+        StackElement::Witness(sigser) => {
+            verify_sersig(secp, sighash, &pk.clone().to_public_key(), &sigser)?;
+            stack.push(StackElement::Satisfied);
+            Ok(Primitives{ pks: vec![pk.clone().to_public_key()], hashlocks: vec![], timelocks: vec![]})
+        }
+        StackElement::Satisfied => Err(Error::CouldnotEvaluate)
+    }
+}
+
+/// Helper function to evaluate a checkmultisig which takes the top of the stack as input
+/// signature and validates it.
+/// Sat: 0 sig1 sig2 ... sig_k, 1 is pushed onto the stack
+/// Unsat: 0 (0)*k, 0 is pushed on the stack
+/// Err: All of other witness result in errors.
+fn evaluate_multi<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    k: usize,
+    keys: &Vec<P>,
+) -> Result<Primitives, Error>
+    where P: ToPublicKey + Clone,
+{
+    let len = stack.len();
+    let sigs = stack.split_off(len - k);
+    let extrazero = stack.pop().expect("Missing additional 0 element in checkmultisig");
+    let mut ret = Primitives{pks: vec![], hashlocks: vec![], timelocks: vec![]};
+
+    //Remove the extra zero from multi-sig check
+    if extrazero != StackElement::Dissatisfied {
+        return Err(Error::CouldnotEvaluate)
+    }
+
+    //Non-satisfaction case
+    let nonsat : Vec<bool> = sigs.iter().
+        map(|sig| *sig == StackElement::Dissatisfied).
+        filter(|empty| *empty).
+        collect();
+    if nonsat.len() == k{
+        stack.push(StackElement::Dissatisfied);
+        return Ok(ret)
+    }
+
+    for witness_sig in sigs {
+        for pk in keys {
+            if let StackElement::Witness(ref sig) = witness_sig {
+                if let Ok(()) = verify_sersig(secp, sighash, &pk.to_public_key(), sig) {
+                    ret.pks.push(pk.clone().to_public_key());
+                    break;
+                }
+            }
+        }
+    }
+    if ret.pks.len() == k {
+        stack.push(StackElement::Satisfied);
+        Ok(ret)
+    } else {
+        Err(Error::CouldnotEvaluate)
+    }
+}
+
+/// Equivalent of `n CHECKSEQUENCEVERIFY`. There is no Unsat condition for CSV, hence result is not
+/// sent using EvalResult
+fn evaluate_csv(age: u32, n: u32) -> Result<Primitives, Error>
+{
+    if age >= n {
+        Ok(Primitives{pks: vec![], hashlocks: vec![], timelocks: vec![n]})
+    } else {
+        Err(Error::LocktimeNotMet(n))
+    }
+}
+
+/// Script: DUP IF n CHECKSEQUENCEVERIFY DROP ENDIF. This does not actually check the timelock on
+/// input 0. Upon input 1, this function does CSV and DROP.
+fn evaluate_time_e( stack: &mut Vec<StackElement>, age: u32, n: u32,) -> Result<Primitives, Error>
+{
+    let top = stack.pop().expect("Witness Stack must contain one element");
+    match top {
+        StackElement::Dissatisfied => {
+            stack.push(StackElement::Dissatisfied);
+            Ok(Primitives{pks: vec![], hashlocks: vec![], timelocks: vec![]})
+        }
+        StackElement::Satisfied => {
+            let res = evaluate_csv(age, n)?;
+            stack.push(StackElement::Satisfied);
+            Ok(res)
+        }
+        _ => Err(Error::CouldnotEvaluate)
+    }
+}
+
+/// helper function for calculating equivalent of HASH256 hash OP_EQUAL
+/// len(preimage) = 32 and SHA256(preimage) = hash
+fn evaluate_hash(stack: &mut Vec<StackElement>, hash: sha256::Hash, preimage: &Vec<u8>)
+                   -> Result<Primitives, Error >
+{
+    if preimage.len() != 32{
+        return Err(Error::VerifyHashFail(hash, preimage.clone()))
+    }
+    if sha256::Hash::hash(preimage) == hash{
+        stack.push(StackElement::Satisfied);
+        Ok(Primitives{pks: vec![], hashlocks: vec![preimage.clone()], timelocks: vec![]})
+    }
+    else{
+        Err(Error::VerifyHashFail(hash, preimage.clone()))
+    }
+}
+
+fn evaluate_hash_t(stack:&mut Vec<StackElement>, hash: sha256::Hash)
+    -> Result<Primitives, Error >
+{
+    let pre_image = stack.pop().expect("Preimage missing");
+    if let StackElement::Witness(pre) = pre_image {
+        evaluate_hash(stack, hash, &pre)
+    } else{
+        Err(Error::CouldnotEvaluate)
+    }
+}
+
+fn evaluate_hash_w(stack: &mut Vec<StackElement>, hash: sha256::Hash)
+    -> Result<Primitives, Error >
+{
+    let stacklen = stack.len();
+    stack.swap(stacklen - 1, stacklen - 2);//swap the last elements
+    let preimage = stack.pop().expect("Preimage");
+    match preimage {
+        StackElement::Dissatisfied => {
+            stack.push(StackElement::Dissatisfied);
+            Ok(Primitives { pks: vec![], hashlocks: vec![], timelocks: vec![] })
+        }
+        StackElement::Witness(pre) => evaluate_hash(stack, hash, &pre),
+        _ => Err(Error::CouldnotEvaluate)
+    }
+}
+
+/// A and B. Evaluates both A and B and then computes BOOLAND
+fn interpret_and_bool<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    age: u32,
+    left: &AstElem<P>,
+    right: &AstElem<P>,
+) -> Result<Primitives, Error >
+    where P: ToPublicKey + Clone,
+{
+    let mut res = left.interpret(secp, stack, sighash, age)?;
+    res.join(&right.interpret(secp, stack, sighash, age)?);
+
+    let left_res = stack.pop().expect("Witness stack has at least one element");
+    let right_res = stack.pop().expect("Witness stack has at least one element");
+    match (left_res, right_res) {
+        (StackElement::Satisfied, StackElement::Satisfied) => {
+            stack.push(StackElement::Satisfied);
+            Ok(res)
+        }
+        (StackElement::Satisfied, StackElement::Dissatisfied) |
+        (StackElement::Dissatisfied, StackElement::Satisfied) |
+        (StackElement::Dissatisfied, StackElement::Dissatisfied) => {
+            //If the script evaluates to false, all primitives inside it are ignored.
+            stack.push(StackElement::Dissatisfied);
+            Ok(Primitives { pks: vec![], hashlocks: vec![], timelocks: vec![] })
+        }
+        _ => unreachable!() //Both expressions must be satisfied or dissatisfied
+    }
+}
+
+/// If !A then 0 else B. Evaluates B only if A is true
+fn interpret_and_casc<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    age: u32,
+    left: &AstElem<P>,
+    right: &AstElem<P>,
+) -> Result<Primitives, Error >
+    where P: ToPublicKey + Clone,
+{
+    let mut res = left.interpret(secp, stack, sighash, age)?;
+    let left_res = stack.pop().expect("Witness stack has at least one element");
+    match left_res {
+        StackElement::Dissatisfied => {
+            stack.push(StackElement::Dissatisfied);
+            Ok(Primitives { pks: vec![], hashlocks: vec![], timelocks: vec![] })
+        }
+        StackElement::Satisfied => {
+            //right is F, will push 1 on stack
+            res.join(&right.interpret(secp, stack, sighash, age)?);
+            Ok(res)
+        }
+        _ => unreachable!() //Left res must be satisfied or dissatisfied
+    }
+}
+
+///A or B. Evaluates both A and B and then computes BOOLAND
+fn interpret_or_bool<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    age: u32,
+    left: &AstElem<P>,
+    right: &AstElem<P>,
+) -> Result<Primitives, Error >
+    where P: ToPublicKey + Clone,
+{
+    let mut res = left.interpret(secp, stack, sighash, age)?;
+    res.join(&right.interpret(secp, stack, sighash, age)?);
+
+    let left_res = stack.pop().expect("Witness stack has at least one element");
+    let right_res = stack.pop().expect("Witness stack has at least one element");
+    match (left_res, right_res) {
+        (StackElement::Dissatisfied, StackElement::Dissatisfied) => {
+            stack.push(StackElement::Dissatisfied);
+            Ok(Primitives { pks: vec![], hashlocks: vec![], timelocks: vec![] })
+        }
+        (StackElement::Satisfied, StackElement::Dissatisfied) |
+        (StackElement::Dissatisfied, StackElement::Satisfied) |
+        (StackElement::Satisfied, StackElement::Satisfied) => {
+            //If the script evaluates to false, all primitives inside it are ignored.
+            stack.push(StackElement::Satisfied);
+            Ok(res)
+        }
+        _ => unreachable!() //Both expressions must be satisfied or dissatisfied
+    }
+}
+
+///if A then 1 else B
+fn interpret_or_casc<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    age: u32,
+    left: &AstElem<P>,
+    right: &AstElem<P>,
+) -> Result<Primitives, Error >
+    where P: ToPublicKey + Clone,
+{
+    let res = left.interpret(secp, stack, sighash, age)?;
+    let left_res = stack.pop().expect("Witness stack has at least one element");
+    match left_res {
+        StackElement::Satisfied => {
+            stack.push(StackElement::Satisfied);
+            Ok(res)
+        }
+        StackElement::Dissatisfied => {
+            //right is either E or T, so it will push Sat/Dissat. We ignore all Primitives from left
+            //since that is Dissatisfied
+            let res = right.interpret(secp, stack, sighash, age)?;
+            let len = stack.len();
+            let right_res = match stack.len() {
+                0 => &StackElement::Satisfied, // In the case of OR_Cont, when right is F
+                _ => stack.get(len - 1).expect("Right result")
+            };
+            match *right_res{
+                StackElement::Dissatisfied =>
+                    Ok(Primitives { pks: vec![], hashlocks: vec![], timelocks: vec![] }),
+                StackElement::Satisfied => Ok(res),
+                StackElement::Witness(..) => unreachable!() //Result of E or T cannot be witness bytes
+            }
+        }
+        _ => unreachable!() //Left res must be satisfied or dissatisfied
+    }
+}
+
+/// If c then left else right
+fn interpret_or_if<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    age: u32,
+    left: &AstElem<P>,
+    right: &AstElem<P>,
+) -> Result<Primitives, Error >
+    where P: ToPublicKey + Clone,
+{
+    let c = stack.pop().expect("Witness stack has at least one element");
+    match c {
+        StackElement::Satisfied => left.interpret(secp, stack, sighash, age),
+        StackElement::Dissatisfied => right.interpret(secp, stack, sighash, age),
+        _ => Err(Error::CouldnotEvaluate)
+    }
+}
+
+///if c then A else B CHECKSIG
+/// or_if followed by CHECKSIG
+fn interpret_or_key<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    age: u32,
+    left: &AstElem<P>,
+    right: &AstElem<P>,
+) -> Result<Primitives, Error >
+    where P: ToPublicKey + Clone,
+{
+    let mut res = interpret_or_if(secp, stack, sighash, age, left, right)?;
+    let pk = stack
+        .pop()
+        .expect("Pubkey expected")
+        .is_witness_or_err()?;
+    let sig = stack
+        .pop()
+        .expect("Witness stack has at least one element");
+    let pk = bitcoin::PublicKey::from_slice(&pk).expect("Public parse error");
+    match sig{
+        StackElement::Dissatisfied => {
+            stack.push(StackElement::Dissatisfied);
+            Ok(Primitives { pks: vec![], hashlocks: vec![], timelocks: vec![] })
+        }
+        StackElement::Witness(sig) => {
+            verify_sersig(secp, sighash, &pk, &sig)?;
+            stack.push(StackElement::Satisfied);
+            res.join(&Primitives{ pks: vec![pk.clone()], hashlocks: vec![], timelocks: vec![]});
+            Ok(res)
+        }
+        _ => Err(Error::CouldnotEvaluate)
+    }
+}
+
+///A + B + ... = k. Evalutes all the subexpressions and checks if EXACTLY k of them are satisfied.
+fn evaluate_thres<P>(
+    secp: &secp256k1::Secp256k1<VerifyOnly>,
+    stack: &mut Vec<StackElement>,
+    sighash: &secp256k1::Message,
+    age: u32,
+    k: usize,
+    subs: &[AstElem<P>],
+) -> Result<Primitives, Error >
+    where P: ToPublicKey + Clone,
+{
+    let mut res = Primitives{pks: vec![], hashlocks:vec![], timelocks:vec![]};
+
+    if k == 0 {
+        stack.push(StackElement::Satisfied);
+        return Ok(res);
+    }
+
+    let mut satisfied = 0;
+
+    for sub in subs.iter() {
+        res.join(&sub.interpret(secp, stack, sighash, age)?);
+        let top = stack.pop().expect("Expression result");
+        match top{
+            StackElement::Satisfied => satisfied += 1,
+            StackElement::Dissatisfied => {}
+            _ => unreachable!() //All Subexpressions must evaluate either true or false
+        }
+    }
+
+    if satisfied == k {
+        stack.push(StackElement::Satisfied);
+        return Ok(res)
+    }else {
+        stack.push(StackElement::Dissatisfied);
+        Err(Error::CouldnotEvaluate)
+    }
+}

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -36,6 +36,7 @@ pub mod astelem;
 pub mod decode;
 pub mod lex;
 pub mod satisfy;
+pub mod evaluate;
 
 use Error;
 use expression;
@@ -43,6 +44,10 @@ use ToPublicKey;
 use policy::AbstractPolicy;
 use self::lex::{lex, TokenIter};
 use self::satisfy::Satisfiable;
+use self::evaluate::Interpretable;
+use self::evaluate::Primitives;
+use secp256k1::{Secp256k1, VerifyOnly};
+use miniscript::evaluate::StackElement;
 
 /// Top-level script AST type
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -158,6 +163,20 @@ impl<P: ToPublicKey> Miniscript<P> {
               H: FnMut(sha256::Hash) -> Option<[u8; 32]>
     {
         self.0.satisfy(keyfn.as_mut(), hashfn.as_mut(), age)
+    }
+
+}
+
+impl<P: ToPublicKey + Clone> Miniscript<P> {
+
+    pub fn interpret(
+        &self,
+        secp: &Secp256k1<VerifyOnly>,
+        stack: &mut Vec<StackElement>,
+        sighash: &secp256k1::Message,
+        age: u32,
+    ) -> Result<Primitives, Error> {
+        self.0.interpret(secp, stack, sighash, age)
     }
 }
 


### PR DESCRIPTION
Added an interpreter for Miniscript which given a satisfying witness to a descriptor, returns the set of public keys, hash preimages, and timelocks that were used. 

I have also added tests to check the "all good" tests. I can add more to check error cases too, but I thought I should get some feedback on the design and code. I will add comments on places where I made some assumptions about the behaviour of the interpreter. 