### PR TITLE
Changed node names time -> time_e, time_t -> time, hash_t -> hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 repository = "https://github.com/apoelstra/miniscript"
 description = "Miniscript: a subset of Bitcoin Script designed for analysis"

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -578,7 +578,7 @@ mod tests {
     #[test]
     pub fn script_pubkey() {
         let bare = Descriptor::<PublicKey>::from_str(
-            "time_t(1000)"
+            "time(1000)"
         ).unwrap();
         assert_eq!(
             bare.script_pubkey(),

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -109,7 +109,7 @@ pub fn parse(tokens: &mut TokenIter) -> Result<AstElem<bitcoin::PublicKey>, Erro
         },
         Token::Equal => {
             Token::Sha256Hash(hash), Token::Sha256, Token::EqualVerify, Token::Number(32), Token::Size => {
-                Ok(AstElem::HashT(hash))
+                Ok(AstElem::Hash(hash))
             },
             Token::Number(k) => {{
                 let mut subs = vec![];
@@ -239,7 +239,7 @@ pub fn parse(tokens: &mut TokenIter) -> Result<AstElem<bitcoin::PublicKey>, Erro
         },
         Token::CheckSequenceVerify => {
             Token::Number(n) => {
-                Ok(AstElem::TimeT(n))
+                Ok(AstElem::Time(n))
             }
         },
         Token::FromAltStack => {
@@ -260,9 +260,9 @@ pub fn parse(tokens: &mut TokenIter) -> Result<AstElem<bitcoin::PublicKey>, Erro
                         Some(Token::Swap) => Ok(AstElem::TimeW(n)),
                         Some(x) => {
                             tokens.un_next(x);
-                            Ok(AstElem::Time(n))
+                            Ok(AstElem::TimeE(n))
                         }
-                        None => Ok(AstElem::Time(n))
+                        None => Ok(AstElem::TimeE(n))
                     }
                 }}
             },

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -310,7 +310,7 @@ mod tests {
                 Box::new(AstElem::Multi(2, keys[0..2].to_owned())),
                 Box::new(AstElem::AndCat(
                      Box::new(AstElem::MultiV(2, keys[3..5].to_owned())),
-                     Box::new(AstElem::TimeT(10000)),
+                     Box::new(AstElem::Time(10000)),
                  ),
              ))),
              "Script(OP_PUSHNUM_2 OP_PUSHBYTES_33 028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa \
@@ -328,7 +328,7 @@ mod tests {
             Box::new(AstElem::Multi(3, keys[0..3].to_owned())),
             Box::new(AstElem::AndCat(
                  Box::new(AstElem::MultiV(2, keys[3..5].to_owned())),
-                 Box::new(AstElem::TimeT(10000)),
+                 Box::new(AstElem::Time(10000)),
             )),
         ));
         let mut abs = miniscript.abstract_policy();
@@ -345,12 +345,12 @@ mod tests {
         assert_eq!(abs.minimum_n_keys(), 3);
 
         roundtrip(
-            &Miniscript(AstElem::TimeT(921)),
+            &Miniscript(AstElem::Time(921)),
             "Script(OP_PUSHBYTES_2 9903 OP_NOP3)"
         );
 
         roundtrip(
-            &Miniscript(AstElem::HashT(sha256::Hash::hash(&[]))),
+            &Miniscript(AstElem::Hash(sha256::Hash::hash(&[]))),
             "Script(OP_SIZE OP_PUSHBYTES_1 20 OP_EQUALVERIFY OP_SHA256 OP_PUSHBYTES_32 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 OP_EQUAL)"
         );
 
@@ -366,7 +366,7 @@ mod tests {
         );
 
         roundtrip(
-            &Miniscript(AstElem::HashT(sha256::Hash::hash(&[]))),
+            &Miniscript(AstElem::Hash(sha256::Hash::hash(&[]))),
             "Script(OP_SIZE OP_PUSHBYTES_1 20 OP_EQUALVERIFY OP_SHA256 OP_PUSHBYTES_32 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 OP_EQUAL)"
         );
 
@@ -392,8 +392,8 @@ mod tests {
         // fuzzer
         roundtrip(
             &Miniscript(AstElem::OrIf(
-                Box::new(AstElem::TimeT(9)),
-                Box::new(AstElem::TimeT(7)),
+                Box::new(AstElem::Time(9)),
+                Box::new(AstElem::Time(7)),
             )),
             "Script(OP_IF OP_PUSHNUM_9 OP_NOP3 OP_ELSE OP_PUSHNUM_7 OP_NOP3 OP_ENDIF)"
         );
@@ -401,10 +401,10 @@ mod tests {
         roundtrip(
             &Miniscript(AstElem::AndCat(
                 Box::new(AstElem::OrIfV(
-                    Box::new(AstElem::TimeT(9)),
-                    Box::new(AstElem::TimeT(7)),
+                    Box::new(AstElem::Time(9)),
+                    Box::new(AstElem::Time(7)),
                 )),
-                Box::new(AstElem::TimeT(7))
+                Box::new(AstElem::Time(7))
             )),
             "Script(OP_IF OP_PUSHNUM_9 OP_NOP3 OP_ELSE OP_PUSHNUM_7 OP_NOP3 OP_ENDIF OP_VERIFY OP_PUSHNUM_7 OP_NOP3)"
         );
@@ -422,7 +422,7 @@ mod tests {
                 AstElem::Thresh(
                     1,
                     vec![
-                        AstElem::Time(1),
+                        AstElem::TimeE(1),
                         AstElem::Wrap(Box::new(AstElem::OrNotif(
                             Box::new(AstElem::TimeF(1)),
                             Box::new(AstElem::Pk(keys[0].clone()))

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -74,12 +74,12 @@ impl<P: ToPublicKey> Satisfiable<P> for AstElem<P> {
             AstElem::PkW(ref p) => satisfy_checksig(p, keyfn),
             AstElem::Multi(k, ref keys) |
             AstElem::MultiV(k, ref keys) => satisfy_checkmultisig(k, keys, keyfn),
-            AstElem::TimeT(t) |
+            AstElem::Time(t) |
             AstElem::TimeV(t) |
             AstElem::TimeF(t) => satisfy_csv(t, age),
-            AstElem::Time(t) |
+            AstElem::TimeE(t) |
             AstElem::TimeW(t) => satisfy_csv(t, age).map(|_| vec![vec![1]]),
-            AstElem::HashT(h) |
+            AstElem::Hash(h) |
             AstElem::HashV(h) |
             AstElem::HashW(h) => satisfy_hashequal(h, hashfn),
             AstElem::Wrap(ref sub) => sub.satisfy(keyfn, hashfn, age),
@@ -126,11 +126,11 @@ impl<P: ToPublicKey> Dissatisfiable<P> for AstElem<P> {
             AstElem::PkV(..) |
             AstElem::PkQ(..) |
             AstElem::MultiV(..) |
-            AstElem::TimeT(..) |
+            AstElem::Time(..) |
             AstElem::TimeV(..) |
             AstElem::TimeF(..) |
-            AstElem::Time(..) |
-            AstElem::HashT(..) |
+            AstElem::TimeE(..) |
+            AstElem::Hash(..) |
             AstElem::HashV(..) => unreachable!(),
             AstElem::Wrap(ref sub) => sub.dissatisfy(),
             AstElem::Likely(..) => vec![vec![1]],


### PR DESCRIPTION
Changed node names `time` -> `time_e`, `time_t` -> `time`, `hash_t` -> `hash`. 

There adds a convention that the T version is always keyword and everything else (if distinct) is keyword_X.