### PR TITLE
Refactor for miniscript to save type information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 
 [dependencies]
 bitcoin = "0.18"
-bitcoin_hashes = "0.4"
+bitcoin_hashes = "0.7"
 
 [dependencies.secp256k1]
 version = "0.12"

--- a/src/descriptor/create_descriptor.rs
+++ b/src/descriptor/create_descriptor.rs
@@ -258,7 +258,6 @@ mod tests {
     use bitcoin::blockdata::opcodes;
     use ToPublicKey;
     use std::str::FromStr;
-    use bitcoin_hashes::hash160;
 
     fn setup_keys_sigs(n: usize)
                        -> ( Vec<PublicKey>, Vec<Vec<u8> >, secp256k1::Message, Secp256k1<VerifyOnly>) {

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -528,10 +528,8 @@ impl<Pk, Pkh> ser::Serialize for Descriptor<Pk, Pkh> where
 
 #[cfg(feature = "serde")]
 impl<'de, Pk, Pkh> de::Deserialize<'de> for Descriptor<Pk, Pkh> where
-    Pk: fmt::Debug + str::FromStr + fmt::Display
-    + Clone,
-    Pkh: fmt::Debug + str::FromStr + fmt::Display
-    + Clone,
+    Pk: fmt::Debug + str::FromStr + fmt::Display + Clone,
+    Pkh: fmt::Debug + str::FromStr + fmt::Display + Clone,
     <Pk as str::FromStr>::Err: ToString,
     <Pkh as str::FromStr>::Err: ToString,
 {
@@ -541,10 +539,8 @@ impl<'de, Pk, Pkh> de::Deserialize<'de> for Descriptor<Pk, Pkh> where
         struct StrVisitor<Qk, Qkh>(PhantomData<(Qk, Qkh)>);
 
         impl<'de, Qk, Qkh> de::Visitor<'de> for StrVisitor<Qk, Qkh> where
-            Qk: fmt::Debug + str::FromStr + fmt::Display
-            + Clone,
-            Qkh: fmt::Debug + str::FromStr + fmt::Display
-            + Clone,
+            Qk: fmt::Debug + str::FromStr + fmt::Display + Clone,
+            Qkh: fmt::Debug + str::FromStr + fmt::Display + Clone,
             <Qk as str::FromStr>::Err: ToString,
             <Qkh as str::FromStr>::Err: ToString,
         {
@@ -582,11 +578,8 @@ mod tests {
     use bitcoin::blockdata::{opcodes, script};
     use bitcoin_hashes::{hash160, sha256};
     use bitcoin_hashes::hex::FromHex;
-    use secp256k1;
-
+    use ::{secp256k1};
     use std::str::FromStr;
-
-    use miniscript::astelem;
     use miniscript::satisfy::BitcoinSig;
     use Miniscript;
     use Descriptor;

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -774,9 +774,7 @@ mod tests {
         }
 
         let satisfier = SimpleSat { sig, pk };
-        let ms = Miniscript::<_, DummyKeyHash>::from(
-            astelem::AstElem::Check(Box::new(astelem::AstElem::Pk(pk)))
-        );
+        let ms: Miniscript<PublicKey, DummyKeyHash> = ms_str!("c:pk({})", pk);
 
         let mut txin = bitcoin::TxIn {
             previous_output: bitcoin::OutPoint::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ use std::{error, fmt, str};
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin_hashes::{Hash, hash160, sha256};
 
-pub use miniscript::astelem::AstElem;
+pub use miniscript::decode::Terminal;
 pub use descriptor::Descriptor;
 pub use miniscript::Miniscript;
 pub use miniscript::satisfy::{BitcoinSig, Satisfier};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,14 +81,17 @@
 //! }
 //! ```
 //!
-
+//!
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
-
 extern crate bitcoin;
 extern crate bitcoin_hashes;
 extern crate secp256k1;
 #[cfg(feature="serde")] extern crate serde;
+
+#[macro_use]
+#[cfg(test)]
+mod macros;
 
 pub mod miniscript;
 pub mod descriptor;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,11 +6,23 @@
 /// Allows tests to create a miniscript directly from string as
 /// `ms_str!("c:or_i(pk({}),pk({}))", pk1, pk2)`
 macro_rules! ms_str {
-    ($($arg:tt)*) => (Miniscript::<PublicKey, hash160::Hash>::from_str(&format!($($arg)*)).unwrap())
+    ($($arg:tt)*) => (Miniscript::from_str(&format!($($arg)*)).unwrap())
+}
+
+/// Allows tests to create a miniscript directly from string as
+/// `ast_str!("c:or_i(pk({}),pk({}))", pk1, pk2)`
+macro_rules! ast_str {
+    ($($arg:tt)*) => (Miniscript::from_str(&format!($($arg)*)).unwrap().into_inner())
 }
 
 /// Allows tests to create a descriptor directly from string as
 /// `des_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
 macro_rules! des_str {
-    ($($arg:tt)*) => (Descriptor::<PublicKey, hash160::Hash>::from_str(&format!($($arg)*)).unwrap())
+    ($($arg:tt)*) => (Descriptor::from_str(&format!($($arg)*)).unwrap())
+}
+
+/// Allows tests to create a descriptor directly from string as
+/// `des_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
+macro_rules! policy_str {
+    ($($arg:tt)*) => (::policy::Concrete::from_str(&format!($($arg)*)).unwrap())
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,16 @@
+//! Macros
+//!
+//! Macros meant to be used inside the Rust Miniscript library
+
+
+/// Allows tests to create a miniscript directly from string as
+/// `ms_str!("c:or_i(pk({}),pk({}))", pk1, pk2)`
+macro_rules! ms_str {
+    ($($arg:tt)*) => (Miniscript::<PublicKey, hash160::Hash>::from_str(&format!($($arg)*)).unwrap())
+}
+
+/// Allows tests to create a descriptor directly from string as
+/// `des_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
+macro_rules! des_str {
+    ($($arg:tt)*) => (Descriptor::<PublicKey, hash160::Hash>::from_str(&format!($($arg)*)).unwrap())
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,20 +9,14 @@ macro_rules! ms_str {
     ($($arg:tt)*) => (Miniscript::from_str(&format!($($arg)*)).unwrap())
 }
 
-/// Allows tests to create a miniscript directly from string as
-/// `ast_str!("c:or_i(pk({}),pk({}))", pk1, pk2)`
-macro_rules! ast_str {
-    ($($arg:tt)*) => (Miniscript::from_str(&format!($($arg)*)).unwrap().into_inner())
-}
-
 /// Allows tests to create a descriptor directly from string as
 /// `des_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
 macro_rules! des_str {
     ($($arg:tt)*) => (Descriptor::from_str(&format!($($arg)*)).unwrap())
 }
 
-/// Allows tests to create a descriptor directly from string as
-/// `des_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
+/// Allows tests to create a concrete policy directly from string as
+/// `polic_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
 macro_rules! policy_str {
     ($($arg:tt)*) => (::policy::Concrete::from_str(&format!($($arg)*)).unwrap())
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,7 +16,7 @@ macro_rules! des_str {
 }
 
 /// Allows tests to create a concrete policy directly from string as
-/// `polic_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
+/// `policy_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
 macro_rules! policy_str {
     ($($arg:tt)*) => (::policy::Concrete::from_str(&format!($($arg)*)).unwrap())
 }

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -503,15 +503,7 @@ impl<Pk, Pkh> expression::FromTree for AstElem<Pk, Pkh> where
                 |x| hash160::Hash::from_hex(x).map(AstElem::Hash160)
             ),
             ("true", 0) => Ok(AstElem::True),
-            ("and_v", 2) => {
-                let expr = expression::binary(top, AstElem::AndV)?;
-                if let AstElem::AndV(_, ref right) = expr {
-                    if let AstElem::True = **right {
-                        return Err(Error::NonCanonicalTrue);
-                    }
-                }
-                Ok(expr)
-            },
+            ("and_v", 2) => expression::binary(top, AstElem::AndV),
             ("and_b", 2) => expression::binary(top, AstElem::AndB),
             ("tern", 3) => Ok(AstElem::AndOr(
                 expression::FromTree::from_tree(&top.args[0])?,

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -351,7 +351,7 @@ where
                 AstElem::AndB(ref l, ref r) =>
                     write!(f, "and_b({:?},{:?})", l, r),
                 AstElem::AndOr(ref a, ref b, ref c) =>
-                    write!(f, "tern({:?},{:?},{:?})", a, c, b),
+                    write!(f, "and_or({:?},{:?},{:?})", a, c, b),
                 AstElem::OrB(ref l, ref r) =>
                     write!(f, "or_b({:?},{:?})", l, r),
                 AstElem::OrD(ref l, ref r) =>
@@ -505,7 +505,7 @@ impl<Pk, Pkh> expression::FromTree for AstElem<Pk, Pkh> where
             ("true", 0) => Ok(AstElem::True),
             ("and_v", 2) => expression::binary(top, AstElem::AndV),
             ("and_b", 2) => expression::binary(top, AstElem::AndB),
-            ("tern", 3) => Ok(AstElem::AndOr(
+            ("and_or", 3) => Ok(AstElem::AndOr(
                 expression::FromTree::from_tree(&top.args[0])?,
                 expression::FromTree::from_tree(&top.args[2])?,
                 expression::FromTree::from_tree(&top.args[1])?,

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -56,7 +56,7 @@ enum NonTerm {
     EndIfElse,
 }
 /// All AST elements
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Terminal<Pk, Pkh> {
     /// `1`
     True,

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -51,7 +51,7 @@ use miniscript::types::extra_props::ExtData;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Miniscript<Pk, Pkh=hash160::Hash>{
     ///A node in the Abstract Syntax Tree(
-    pub node: astelem::AstElem<Pk, Pkh>,
+    pub node: decode::Terminal<Pk, Pkh>,
     ///The correctness and malleability type information for the AST node
     pub ty: types::Type,
     ///Additional information helpful for extra analysis.
@@ -75,7 +75,7 @@ impl<Pk, Pkh> Miniscript<Pk, Pkh>
     /// Add type information(Type and Extdata) to Miniscript based on
     /// `AstElem` fragment. Dependant on display and clone because it is used
     /// in creating Miniscript from String
-    pub fn from_ast(t: astelem::AstElem<Pk, Pkh>) -> Result< Miniscript<Pk, Pkh>, Error> {
+    pub fn from_ast(t: decode::Terminal<Pk, Pkh>) -> Result< Miniscript<Pk, Pkh>, Error> {
         Ok(Miniscript{
             ty: Type::type_check(&t, |_| None)?,
             ext: ExtData::type_check(&t, |_| None)?,
@@ -92,7 +92,7 @@ impl<Pk: fmt::Display, Pkh: fmt::Display> fmt::Display for Miniscript<Pk, Pkh> {
 
 impl<Pk, Pkh> Miniscript<Pk, Pkh> {
     /// Extracts the `AstElem` representing the root of the miniscript
-    pub fn into_inner(self) -> astelem::AstElem<Pk, Pkh> {
+    pub fn into_inner(self) -> decode::Terminal<Pk, Pkh> {
         self.node
     }
 }
@@ -236,7 +236,7 @@ impl<Pk, Pkh> expression::FromTree for Miniscript<Pk, Pkh> where
     /// Parse an expression tree into a Miniscript. As a general rule, this
     /// should not be called directly; rather go through the descriptor API.
     fn from_tree(top: &expression::Tree) -> Result<Miniscript<Pk, Pkh>, Error> {
-        let inner: astelem::AstElem<Pk, Pkh>
+        let inner: decode::Terminal<Pk, Pkh>
             = expression::FromTree::from_tree(top)?;
         Ok(Miniscript {
             ty: Type::type_check(&inner, |_| None)?,
@@ -333,7 +333,7 @@ mod tests {
     use super::Miniscript;
     use ::{DummyKey};
     use DummyKeyHash;
-    use miniscript::astelem::AstElem;
+    use miniscript::decode::Terminal;
     use miniscript::types::{self, Property, Type, ExtData};
     use hex_script;
     use policy::Liftable;
@@ -428,9 +428,9 @@ mod tests {
         let hash = hash160::Hash::from_inner([17; 20]);
 
         let pk_ms :Miniscript<DummyKey, DummyKeyHash> = Miniscript {
-            node: AstElem::Check(Box::new(
+            node: Terminal::Check(Box::new(
                 Miniscript {
-                    node: AstElem::Pk(DummyKey),
+                    node: Terminal::Pk(DummyKey),
                     ty: Type::from_pk(),
                     ext: types::extra_props::ExtData::from_pk()
                 })),
@@ -443,9 +443,9 @@ mod tests {
         );
 
         let pkh_ms :Miniscript<DummyKey, DummyKeyHash> = Miniscript {
-            node: AstElem::Check(Box::new(
+            node: Terminal::Check(Box::new(
                 Miniscript {
-                    node: AstElem::PkH(DummyKeyHash),
+                    node: Terminal::PkH(DummyKeyHash),
                     ty: Type::from_pk_h(),
                     ext: types::extra_props::ExtData::from_pk_h()
                 })),
@@ -459,9 +459,9 @@ mod tests {
         );
 
         let pk_ms :Miniscript<PublicKey, hash160::Hash> = Miniscript {
-            node: AstElem::Check(Box::new(
+            node: Terminal::Check(Box::new(
                 Miniscript {
-                    node: AstElem::Pk(pk),
+                    node: Terminal::Pk(pk),
                     ty: Type::from_pk(),
                     ext: types::extra_props::ExtData::from_pk()
                 })),
@@ -476,9 +476,9 @@ mod tests {
         );
 
         let pkh_ms :Miniscript<PublicKey, hash160::Hash> = Miniscript {
-            node: AstElem::Check(Box::new(
+            node: Terminal::Check(Box::new(
                 Miniscript {
-                    node: AstElem::PkH(hash),
+                    node: Terminal::PkH(hash),
                     ty: Type::from_pk_h(),
                     ext: types::extra_props::ExtData::from_pk_h()
                 })),

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -27,7 +27,7 @@
 #[cfg(feature = "serde")] use serde::{de, ser};
 use std::{fmt, str};
 
-use bitcoin;
+use ::{bitcoin};
 use bitcoin::blockdata::script;
 use bitcoin_hashes::hash160;
 
@@ -44,23 +44,20 @@ use ToPublicKeyHash;
 use self::lex::{lex, TokenIter};
 use self::satisfy::{Satisfiable, Satisfier};
 use self::types::Property;
+use miniscript::types::Type;
+use miniscript::types::extra_props::ExtData;
 
 /// Top-level script AST type
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Miniscript<Pk, Pkh=hash160::Hash>(astelem::AstElem<Pk, Pkh>);
-
-impl<Pk, Pkh> From<astelem::AstElem<Pk, Pkh>> for Miniscript<Pk, Pkh>
-where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
-{
-    fn from(t: astelem::AstElem<Pk, Pkh>) -> Miniscript<Pk, Pkh> {
-        let type_check = types::Type::type_check(&t, |_| None)
-            .expect("typecheck in Miniscript::from");
-        assert!(type_check.corr.base == types::Base::B);
-        Miniscript(t)
-    }
+pub struct Miniscript<Pk, Pkh=hash160::Hash>{
+    ///A node in the Abstract Syntax Tree(
+    pub node: astelem::AstElem<Pk, Pkh>,
+    ///The correctness and malleability type information for the AST node
+    pub ty: types::Type,
+    ///Additional information helpful for extra analysis.
+    pub ext: types::extra_props::ExtData,
 }
+
 
 impl<Pk, Pkh> fmt::Debug for Miniscript<Pk, Pkh>
 where
@@ -68,24 +65,35 @@ where
     Pkh: Clone + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.0)
+        write!(f, "{:?}", self.node)
+    }
+}
+
+impl<Pk, Pkh> Miniscript<Pk, Pkh>
+    where Pk : fmt::Debug + fmt::Display + Clone, Pkh: fmt::Debug + fmt::Display + Clone
+{
+    /// Add type information(Type and Extdata) to Miniscript based on
+    /// `AstElem` fragment. Dependant on display and clone because it is used
+    /// in creating Miniscript from String
+    pub fn from_ast(t: astelem::AstElem<Pk, Pkh>) -> Result< Miniscript<Pk, Pkh>, Error> {
+        Ok(Miniscript{
+            ty: Type::type_check(&t, |_| None)?,
+            ext: ExtData::type_check(&t, |_| None)?,
+            node: t,
+        })
     }
 }
 
 impl<Pk: fmt::Display, Pkh: fmt::Display> fmt::Display for Miniscript<Pk, Pkh> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.node)
     }
 }
 
 impl<Pk, Pkh> Miniscript<Pk, Pkh> {
     /// Extracts the `AstElem` representing the root of the miniscript
     pub fn into_inner(self) -> astelem::AstElem<Pk, Pkh> {
-        self.0
-    }
-    /// Extracts the `AstElem` representing the root of the miniscript
-    pub fn as_inner(&self) -> &astelem::AstElem<Pk, Pkh> {
-        &self.0
+        self.node
     }
 }
 
@@ -98,7 +106,7 @@ impl Miniscript<bitcoin::PublicKey, hash160::Hash> {
         let mut iter = TokenIter::new(tokens);
 
         let top = decode::parse(&mut iter)?;
-        let type_check = types::Type::type_check(&top, |_| None)?;
+        let type_check = types::Type::type_check(&top.node, |_| None)?;
         if type_check.corr.base != types::Base::B {
             return Err(Error::NonTopLevel(
                 format!("{:?}", top)
@@ -107,7 +115,7 @@ impl Miniscript<bitcoin::PublicKey, hash160::Hash> {
         if let Some(leading) = iter.next() {
             Err(Error::Trailing(leading.to_string()))
         } else {
-            Ok(Miniscript(top))
+            Ok(top)
         }
     }
 }
@@ -115,7 +123,7 @@ impl Miniscript<bitcoin::PublicKey, hash160::Hash> {
 impl<Pk: ToPublicKey, Pkh: ToPublicKeyHash> Miniscript<Pk, Pkh> {
     /// Encode as a Bitcoin script
     pub fn encode(&self) -> script::Script {
-        self.0.encode(script::Builder::new()).into_script()
+        self.node.encode(script::Builder::new()).into_script()
     }
 
     /// Size, in bytes of the script-pubkey. If this Miniscript is used outside
@@ -126,7 +134,7 @@ impl<Pk: ToPublicKey, Pkh: ToPublicKeyHash> Miniscript<Pk, Pkh> {
     /// to instead call the corresponding function on a `Descriptor`, which
     /// will handle the segwit/non-segwit technicalities for you.
     pub fn script_size(&self) -> usize {
-        self.0.script_size()
+        self.node.script_size()
     }
 
     /// Maximum number of witness elements used to satisfy the Miniscript
@@ -138,7 +146,7 @@ impl<Pk: ToPublicKey, Pkh: ToPublicKeyHash> Miniscript<Pk, Pkh> {
     /// not correspond to semantically sane Scripts. (Such scripts should be
     /// rejected at parse time. Any exceptions are bugs.)
     pub fn max_satisfaction_witness_elements(&self) -> usize {
-        1 + self.0.max_satisfaction_witness_elements()
+        1 + self.node.max_satisfaction_witness_elements()
     }
 
     /// Maximum size, in bytes, of a satisfying witness. For Segwit outputs
@@ -158,17 +166,24 @@ impl<Pk: ToPublicKey, Pkh: ToPublicKeyHash> Miniscript<Pk, Pkh> {
     /// correspond to semantically sane Scripts. (Such scripts should be
     /// rejected at parse time. Any exceptions are bugs.)
     pub fn max_satisfaction_size(&self, one_cost: usize) -> usize {
-        self.0.max_satisfaction_size(one_cost)
+        self.node.max_satisfaction_size(one_cost)
     }
 }
+
 
 impl<Pk, Pkh: Clone> Miniscript<Pk, Pkh> {
     pub fn translate_pk<F, Q, E>(&self, translatefn: F)
         -> Result<Miniscript<Q, Pkh>, E>
         where F: FnMut(&Pk) -> Result<Q, E>
     {
-        let inner = self.0.translate_pk(translatefn)?;
-        Ok(Miniscript(inner))
+        let inner = self.node.translate_pk(translatefn)?;
+        Ok(Miniscript{
+            //directly copying the type nad ext is safe because translating public
+            //key should not change any properties
+            ty: self.ty,
+            ext: self.ext,
+            node: inner,
+        })
     }
 }
 
@@ -177,8 +192,14 @@ impl<Pk: Clone, Pkh> Miniscript<Pk, Pkh> {
         -> Result<Miniscript<Pk, Q>, E>
         where F: FnMut(&Pkh) -> Result<Q, E>
     {
-        let inner = self.0.translate_pkh(translatefn)?;
-        Ok(Miniscript(inner))
+        let inner = self.node.translate_pkh(translatefn)?;
+        Ok(Miniscript{
+            //directly copying the type nad ext is safe because translating public
+            //key should not change any properties
+            ty: self.ty,
+            ext: self.ext,
+            node: inner,
+        })
     }
 }
 
@@ -191,7 +212,18 @@ impl<Pk, Pkh> Miniscript<Pk, Pkh> {
         age: u32,
         height: u32,
     ) -> Option<Vec<Vec<u8>>> {
-        self.0.satisfy(satisfier, age, height)
+        self.node.satisfy(satisfier, age, height)
+    }
+}
+
+impl<Pk, Pkh> expression::FromTree for Box<Miniscript<Pk, Pkh>> where
+    Pk: str::FromStr + fmt::Display + fmt::Debug + Clone,
+    Pkh: str::FromStr + fmt::Display + fmt::Debug + Clone,
+    <Pk as str::FromStr>::Err: ToString,
+    <Pkh as str::FromStr>::Err: ToString,
+{
+    fn from_tree(top: &expression::Tree) -> Result<Box<Miniscript<Pk, Pkh>>, Error> {
+        Ok(Box::new(expression::FromTree::from_tree(top)?))
     }
 }
 
@@ -206,12 +238,11 @@ impl<Pk, Pkh> expression::FromTree for Miniscript<Pk, Pkh> where
     fn from_tree(top: &expression::Tree) -> Result<Miniscript<Pk, Pkh>, Error> {
         let inner: astelem::AstElem<Pk, Pkh>
             = expression::FromTree::from_tree(top)?;
-        let type_check = types::Type::type_check(&inner, |_| None)?;
-        if type_check.corr.base == types::Base::B {
-            Ok(Miniscript(inner))
-        } else {
-            Err(Error::NonTopLevel(format!("{:?}", inner)))
-        }
+        Ok(Miniscript {
+            ty: Type::type_check(&inner, |_| None)?,
+            ext: ExtData::type_check(&inner, |_| None)?,
+            node: inner,
+        })
     }
 }
 
@@ -231,7 +262,13 @@ impl<Pk, Pkh> str::FromStr for Miniscript<Pk, Pkh> where
         }
 
         let top = expression::Tree::from_str(s)?;
-        expression::FromTree::from_tree(&top)
+        let ms : Miniscript<Pk, Pkh> = expression::FromTree::from_tree(&top)?;
+
+        if ms.ty.corr.base != types::Base::B {
+            Err(Error::NonTopLevel(format!("{:?}", ms)))
+        } else {
+            Ok(ms)
+        }
     }
 }
 
@@ -247,10 +284,8 @@ impl<Pk, Pkh> ser::Serialize for Miniscript<Pk, Pkh> where
 
 #[cfg(feature = "serde")]
 impl<'de, Pk, Pkh> de::Deserialize<'de> for Miniscript<Pk, Pkh> where
-    Pk: fmt::Debug + str::FromStr + fmt::Display
-    + Clone,
-    Pkh: fmt::Debug + str::FromStr + fmt::Display
-    + Clone,
+    Pk: fmt::Debug + str::FromStr + fmt::Display + Clone,
+    Pkh: fmt::Debug + str::FromStr + fmt::Display + Clone,
     <Pk as str::FromStr>::Err: ToString,
     <Pkh as str::FromStr>::Err: ToString,
 {
@@ -261,10 +296,8 @@ impl<'de, Pk, Pkh> de::Deserialize<'de> for Miniscript<Pk, Pkh> where
         struct StrVisitor<Qk, Qkh>(PhantomData<(Qk, Qkh)>);
 
         impl<'de, Qk, Qkh> de::Visitor<'de> for StrVisitor<Qk, Qkh> where
-            Qk: fmt::Debug + str::FromStr + fmt::Display
-            + Clone,
-            Qkh: fmt::Debug + str::FromStr + fmt::Display
-            + Clone,
+            Qk: fmt::Debug + str::FromStr + fmt::Display + Clone,
+            Qkh: fmt::Debug + str::FromStr + fmt::Display + Clone,
             <Qk as str::FromStr>::Err: ToString,
             <Qkh as str::FromStr>::Err: ToString,
         {
@@ -298,10 +331,10 @@ impl<'de, Pk, Pkh> de::Deserialize<'de> for Miniscript<Pk, Pkh> where
 #[cfg(test)]
 mod tests {
     use super::Miniscript;
-    use DummyKey;
+    use ::{DummyKey};
     use DummyKeyHash;
     use miniscript::astelem::AstElem;
-    use miniscript::types::{self, Property};
+    use miniscript::types::{self, Property, Type, ExtData};
     use hex_script;
     use policy::Liftable;
 
@@ -311,7 +344,6 @@ mod tests {
     use std::fmt;
     use std::str::FromStr;
 
-    type DummyScript = Miniscript<DummyKey, DummyKeyHash>;
     type BScript = Miniscript<bitcoin::PublicKey, hash160::Hash>;
 
     fn pubkeys(n: usize) -> Vec<PublicKey> {
@@ -349,9 +381,7 @@ mod tests {
         Str1: Into<Option<&'static str>>,
         Str2: Into<Option<&'static str>>,
     {
-        let type_check = types::Type::type_check(&script.0, |_| None)
-            .expect("typecheck");
-        assert!(type_check.corr.base == types::Base::B);
+        assert_eq!(script.ty.corr.base, types::Base::B);
         let debug = format!("{:?}", script);
         let display = format!("{}", script);
         if let Some(expected) = expected_debug.into() {
@@ -369,9 +399,7 @@ mod tests {
         script: BScript,
         expected_hex: Str1,
     ) {
-        let type_check = types::Type::type_check(&script.0, |_| None)
-            .expect("typecheck");
-        assert!(type_check.corr.base == types::Base::B);
+        assert_eq!(script.ty.corr.base, types::Base::B);
         let bitcoin_script = script.encode();
         assert_eq!(bitcoin_script.len(), script.script_size());
         if let Some(expected) = expected_hex.into() {
@@ -382,17 +410,14 @@ mod tests {
         assert_eq!(roundtrip, script);
     }
 
-    fn roundtrip(tree: &BScript, s: &str) {
-        let type_check = match types::Type::type_check(&tree.0, |_| None) {
-            Ok(type_check) => type_check,
-            Err(e) => panic!("typecheck: {}", e),
-        };
-        assert!(type_check.corr.base == types::Base::B);
+    fn roundtrip(tree: &Miniscript<PublicKey, hash160::Hash>, s: &str) where
+    {
+        assert_eq!(tree.ty.corr.base, types::Base::B);
         let ser = tree.encode();
         assert_eq!(ser.len(), tree.script_size());
         assert_eq!(ser.to_string(), s);
         let deser = Miniscript::parse(&ser).expect("deserialize result of serialize");
-        assert_eq!(tree, &deser);
+        assert_eq!(*tree, deser);
     }
 
     #[test]
@@ -402,27 +427,67 @@ mod tests {
         ").unwrap();
         let hash = hash160::Hash::from_inner([17; 20]);
 
-        string_rtt(
-            DummyScript::from(AstElem::Check(Box::new(AstElem::Pk(DummyKey)))),
+        let pk_ms :Miniscript<DummyKey, DummyKeyHash> = Miniscript {
+            node: AstElem::Check(Box::new(
+                Miniscript {
+                    node: AstElem::Pk(DummyKey),
+                    ty: Type::from_pk(),
+                    ext: types::extra_props::ExtData::from_pk()
+                })),
+            ty: Type::cast_check(Type::from_pk()).unwrap(),
+            ext: ExtData::cast_check(ExtData::from_pk()).unwrap()
+        };
+        string_rtt(pk_ms,
             "[B/onduesm]c:[K/onduesm]pk(DummyKey)",
             "c:pk()",
         );
 
+        let pkh_ms :Miniscript<DummyKey, DummyKeyHash> = Miniscript {
+            node: AstElem::Check(Box::new(
+                Miniscript {
+                    node: AstElem::PkH(DummyKeyHash),
+                    ty: Type::from_pk_h(),
+                    ext: types::extra_props::ExtData::from_pk_h()
+                })),
+            ty: Type::cast_check(Type::from_pk_h()).unwrap(),
+            ext: ExtData::cast_check(ExtData::from_pk_h()).unwrap()
+        };
         string_rtt(
-            DummyScript::from(AstElem::Check(
-                Box::new(AstElem::PkH(DummyKeyHash))
-            )),
+            pkh_ms,
             "[B/nduesm]c:[K/nduesm]pk_h(DummyKeyHash)",
             "c:pk_h()",
         );
 
+        let pk_ms :Miniscript<PublicKey, hash160::Hash> = Miniscript {
+            node: AstElem::Check(Box::new(
+                Miniscript {
+                    node: AstElem::Pk(pk),
+                    ty: Type::from_pk(),
+                    ext: types::extra_props::ExtData::from_pk()
+                })),
+            ty: Type::cast_check(Type::from_pk()).unwrap(),
+            ext: ExtData::cast_check(ExtData::from_pk()).unwrap()
+        };
+
         script_rtt(
-            BScript::from(AstElem::Check(Box::new(AstElem::Pk(pk)))),
+            pk_ms,
             "21020202020202020202020202020202020202020202020202020202020\
              202020202ac",
         );
+
+        let pkh_ms :Miniscript<PublicKey, hash160::Hash> = Miniscript {
+            node: AstElem::Check(Box::new(
+                Miniscript {
+                    node: AstElem::PkH(hash),
+                    ty: Type::from_pk_h(),
+                    ext: types::extra_props::ExtData::from_pk_h()
+                })),
+            ty: Type::cast_check(Type::from_pk_h()).unwrap(),
+            ext: ExtData::cast_check(ExtData::from_pk_h()).unwrap()
+        };
+
         script_rtt(
-            BScript::from(AstElem::Check(Box::new(AstElem::PkH(hash)))),
+        pkh_ms,
             "76a914111111111111111111111111111111111111111188ac",
         );
     }
@@ -518,6 +583,7 @@ mod tests {
         assert!(Miniscript::parse(&hex_script("00")).is_ok()); // FALSE
         assert!(Miniscript::parse(&hex_script("51")).is_ok()); // TRUE
         assert!(Miniscript::parse(&hex_script("69")).is_err()); // VERIFY
+        assert!(Miniscript::parse(&hex_script("0000")).is_err()); //and_v(FALSE,FALSE)
         assert!(Miniscript::parse(&hex_script("1001")).is_err()); // incomplete push
         assert!(Miniscript::parse(&hex_script("03990300b2")).is_err()); // non-minimal #
         assert!(Miniscript::parse(&hex_script("8559b2")).is_err()); // leading bytes

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -48,7 +48,7 @@ use miniscript::types::Type;
 use miniscript::types::extra_props::ExtData;
 
 /// Top-level script AST type
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Miniscript<Pk, Pkh=hash160::Hash>{
     ///A node in the Abstract Syntax Tree(
     pub node: decode::Terminal<Pk, Pkh>,
@@ -73,8 +73,8 @@ impl<Pk, Pkh> Miniscript<Pk, Pkh>
     where Pk : fmt::Debug + fmt::Display + Clone, Pkh: fmt::Debug + fmt::Display + Clone
 {
     /// Add type information(Type and Extdata) to Miniscript based on
-    /// `AstElem` fragment. Dependant on display and clone because it is used
-    /// in creating Miniscript from String
+    /// `AstElem` fragment. Dependent on display and clone because of Error
+    /// Display code of type_check.
     pub fn from_ast(t: decode::Terminal<Pk, Pkh>) -> Result< Miniscript<Pk, Pkh>, Error> {
         Ok(Miniscript{
             ty: Type::type_check(&t, |_| None)?,
@@ -178,7 +178,7 @@ impl<Pk, Pkh: Clone> Miniscript<Pk, Pkh> {
     {
         let inner = self.node.translate_pk(translatefn)?;
         Ok(Miniscript{
-            //directly copying the type nad ext is safe because translating public
+            //directly copying the type and ext is safe because translating public
             //key should not change any properties
             ty: self.ty,
             ext: self.ext,
@@ -194,7 +194,7 @@ impl<Pk: Clone, Pkh> Miniscript<Pk, Pkh> {
     {
         let inner = self.node.translate_pkh(translatefn)?;
         Ok(Miniscript{
-            //directly copying the type nad ext is safe because translating public
+            //directly copying the type and ext is safe because translating public
             //key should not change any properties
             ty: self.ty,
             ext: self.ext,

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -1,0 +1,443 @@
+//! Other miscellaneous type properties which are not related to
+//! correctness or malleability.
+
+use super::{ErrorKind, Property, Error};
+use miniscript::astelem::AstElem;
+use script_num_size;
+
+/// Whether a fragment is OK to be used in non-segwit scripts
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum LegacySafe {
+    /// The fragment can be used in pre-segwit contexts without concern
+    /// about malleability attacks/unbounded 3rd-party fee stuffing. This
+    /// means it has no `pk_h` constructions (cannot estimate public key
+    /// size from a hash) and no `d:`/`or_i` constructions (cannot control
+    /// the size of the switch input to `OP_IF`)
+    LegacySafe,
+    /// This fragment can only be safely used with Segwit
+    SegwitOnly,
+}
+
+/// Structure representing the extra type properties of a fragment which are
+/// relevant to legacy(pre-segwit) safety and fee estimation. If a fragment is
+/// used in pre-segwit transactions it will only be malleable but still is
+/// correct and sound.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct ExtData{
+    ///enum sorting whether the fragment is safe to be in used in pre-segwit context
+    pub legacy_safe: LegacySafe,
+    /// The number of bytes needed to encode its scriptpubkey
+    pub pk_cost: usize,
+    /// Whether this fragment can be verify-wrapped for free
+    pub has_verify_form: bool,
+}
+
+impl Property for ExtData {
+    fn sanity_checks(&self) {
+        //No sanity checks
+    }
+
+    fn from_true() -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: 1,
+            has_verify_form: false,
+        }
+    }
+
+    fn from_false() -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: 1,
+            has_verify_form: false,
+        }
+    }
+
+    fn from_pk() -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: 34,
+            has_verify_form: false,
+        }
+    }
+
+    fn from_pk_h() -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::SegwitOnly,
+            pk_cost: 24,
+            has_verify_form: false,
+        }
+    }
+
+    fn from_multi(k: usize, n: usize) -> Self {
+        let num_cost = match(k > 16, n > 16) {
+            (true, true) => 4,
+            (false, true) => 3,
+            (true, false) => 3,
+            (false, false) => 2,
+        };
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: num_cost + 34 * n + 1,
+            has_verify_form: true,
+        }
+    }
+
+    fn from_hash() -> Self {
+        //never called directly
+        unreachable!()
+    }
+
+    fn from_sha256() -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: 33 + 6,
+            has_verify_form: true,
+        }
+    }
+
+    fn from_hash256() -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: 33 + 6,
+            has_verify_form: true,
+        }
+    }
+
+    fn from_ripemd160() -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: 21 + 6,
+            has_verify_form: true,
+        }
+    }
+
+    fn from_hash160() -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: 21 + 6,
+            has_verify_form: true,
+        }
+    }
+
+    fn from_time(t: u32) -> Self {
+        ExtData {
+            legacy_safe: LegacySafe::LegacySafe,
+            pk_cost: script_num_size(t as usize) + 1,
+            has_verify_form: false,
+        }
+    }
+    fn cast_alt(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + 2,
+            has_verify_form: false,
+        })
+    }
+
+    fn cast_swap(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + 1,
+            has_verify_form: self.has_verify_form,
+        })
+    }
+
+    fn cast_check(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + 1,
+            has_verify_form: true,
+        })
+    }
+
+    fn cast_dupif(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: LegacySafe::SegwitOnly,
+            pk_cost: self.pk_cost + 3,
+            has_verify_form: false,
+        })
+    }
+
+    fn cast_verify(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + if self.has_verify_form { 0 } else { 1 },
+            has_verify_form: false,
+        })
+    }
+
+    fn cast_nonzero(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + 4,
+            has_verify_form: false,
+        })
+    }
+
+    fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + 1,
+            has_verify_form: false,
+        })
+    }
+
+    fn cast_true(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + 1,
+            has_verify_form: false,
+        })
+    }
+
+    fn cast_or_i_false(self) -> Result<Self, ErrorKind> {
+        // never called directly
+        unreachable!()
+    }
+
+    fn cast_unlikely(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + 4,
+            has_verify_form: false,
+        })
+    }
+
+    fn cast_likely(self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: self.legacy_safe,
+            pk_cost: self.pk_cost + 4,
+            has_verify_form: false,
+        })
+    }
+
+    fn and_b(l: Self, r: Self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
+            pk_cost: l.pk_cost + r.pk_cost + 1,
+            has_verify_form: false,
+        })
+    }
+
+    fn and_v(l: Self, r: Self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
+            pk_cost: l.pk_cost + r.pk_cost,
+            has_verify_form: r.has_verify_form,
+        })
+    }
+
+    fn or_b(l: Self, r: Self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
+            pk_cost: l.pk_cost + r.pk_cost + 1,
+            has_verify_form: false,
+        })
+    }
+
+    fn or_d(l: Self, r: Self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: LegacySafe::SegwitOnly,
+            pk_cost: l.pk_cost + r.pk_cost + 3,
+            has_verify_form: l.has_verify_form && r.has_verify_form,
+        })
+    }
+
+    fn or_c(l: Self, r: Self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
+            pk_cost: l.pk_cost + r.pk_cost + 2,
+            has_verify_form: false,
+        })
+    }
+
+    fn or_i(l: Self, r: Self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
+            pk_cost: l.pk_cost + r.pk_cost + 3,
+            has_verify_form: l.has_verify_form && r.has_verify_form,
+        })
+    }
+
+    fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
+        Ok(ExtData {
+            legacy_safe: legacy_safe2(
+                legacy_safe2(a.legacy_safe, b.legacy_safe),c.legacy_safe),
+            pk_cost: a.pk_cost + b.pk_cost + c.pk_cost + 3,
+            has_verify_form: b.has_verify_form && c.has_verify_form,
+        })
+    }
+
+    fn threshold<S>(
+        k: usize,
+        n: usize,
+        mut sub_ck: S,
+    ) -> Result<Self, ErrorKind>
+        where S: FnMut(usize) -> Result<Self, ErrorKind>
+    {
+        let mut pk_cost = 1 + script_num_size(k);
+        let mut legacy_safe = LegacySafe::LegacySafe;
+        for i in 0..n {
+
+            let sub = sub_ck(i)?;
+            pk_cost += sub.pk_cost;
+            legacy_safe = legacy_safe2(legacy_safe, sub.legacy_safe);
+        }
+        Ok(ExtData {
+            legacy_safe: legacy_safe,
+            pk_cost: pk_cost,
+            has_verify_form: true,
+        })
+    }
+
+    /// Compute the type of a fragment assuming all the children of
+    /// Miniscript have been computed already.
+    fn type_check<Pk, Pkh, C>(
+        fragment: &AstElem<Pk, Pkh>,
+        _child: C,
+    ) -> Result<Self, Error<Pk, Pkh>>
+        where
+            C: FnMut(usize) -> Option<Self>,
+            Pk: Clone,
+            Pkh: Clone,
+    {
+        let wrap_err = |result: Result<Self, ErrorKind>| result
+            .map_err(|kind| Error {
+                fragment: fragment.clone(),
+                error: kind,
+            });
+
+        let ret = match *fragment {
+            AstElem::True => Ok(Self::from_true()),
+            AstElem::False => Ok(Self::from_false()),
+            AstElem::Pk(..) => Ok(Self::from_pk()),
+            AstElem::PkH(..) => Ok(Self::from_pk_h()),
+            AstElem::ThreshM(k, ref pks) => {
+                if k == 0 {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::ZeroThreshold,
+                    });
+                }
+                if k > pks.len() {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::OverThreshold(k, pks.len()),
+                    });
+                }
+                Ok(Self::from_multi(k, pks.len()))
+            },
+            AstElem::After(t) => {
+                if t == 0 {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::ZeroTime,
+                    });
+                }
+                Ok(Self::from_after(t))
+            },
+            AstElem::Older(t) => {
+                // FIXME check if t > 2^31 - 1
+                if t == 0 {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::ZeroTime,
+                    });
+                }
+                Ok(Self::from_older(t))
+            },
+            AstElem::Sha256(..) => Ok(Self::from_sha256()),
+            AstElem::Hash256(..) => Ok(Self::from_hash256()),
+            AstElem::Ripemd160(..) => Ok(Self::from_ripemd160()),
+            AstElem::Hash160(..) => Ok(Self::from_hash160()),
+            AstElem::Alt(ref sub) =>
+                wrap_err(Self::cast_alt(sub.ext.clone())),
+            AstElem::Swap(ref sub) =>
+                wrap_err(Self::cast_swap(sub.ext.clone())),
+            AstElem::Check(ref sub) =>
+                wrap_err(Self::cast_check(sub.ext.clone())),
+            AstElem::DupIf(ref sub) =>
+                wrap_err(Self::cast_dupif(sub.ext.clone())),
+            AstElem::Verify(ref sub) =>
+                wrap_err(Self::cast_verify(sub.ext.clone())),
+            AstElem::NonZero(ref sub) =>
+                wrap_err(Self::cast_nonzero(sub.ext.clone())),
+            AstElem::ZeroNotEqual(ref sub) =>
+                wrap_err(Self::cast_zeronotequal(sub.ext.clone())),
+            AstElem::AndB(ref l, ref r) => {
+                let ltype = l.ext.clone();
+                let rtype = r.ext.clone();
+                wrap_err(Self::and_b(ltype, rtype))
+            },
+            AstElem::AndV(ref l, ref r) => {
+                let ltype = l.ext.clone();
+                let rtype = r.ext.clone();
+                wrap_err(Self::and_v(ltype, rtype))
+            },
+            AstElem::OrB(ref l, ref r) => {
+                let ltype = l.ext.clone();
+                let rtype = r.ext.clone();
+                wrap_err(Self::or_b(ltype, rtype))
+            },
+            AstElem::OrD(ref l, ref r) => {
+                let ltype = l.ext.clone();
+                let rtype = r.ext.clone();
+                wrap_err(Self::or_d(ltype, rtype))
+            },
+            AstElem::OrC(ref l, ref r) => {
+                let ltype = l.ext.clone();
+                let rtype = r.ext.clone();
+                wrap_err(Self::or_c(ltype, rtype))
+            },
+            AstElem::OrI(ref l, ref r) => {
+                let ltype = l.ext.clone();
+                let rtype = r.ext.clone();
+                wrap_err(Self::or_i(ltype, rtype))
+            },
+            AstElem::AndOr(ref a, ref b, ref c) => {
+                let atype = a.ext.clone();
+                let btype = b.ext.clone();
+                let ctype = c.ext.clone();
+                wrap_err(Self::and_or(atype, btype, ctype))
+            },
+            AstElem::Thresh(k, ref subs) => {
+                if k == 0 {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::ZeroThreshold,
+                    });
+                }
+                if k > subs.len() {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::OverThreshold(k, subs.len()),
+                    });
+                }
+
+                let res = Self::threshold(
+                    k,
+                    subs.len(),
+                    |n| Ok(subs[n].ext.clone())
+                );
+
+                res.map_err(|kind| Error {
+                    fragment: fragment.clone(),
+                    error: kind,
+                })
+            },
+        };
+        if let Ok(ref ret) = ret {
+            ret.sanity_checks()
+        }
+        ret
+    }
+}
+
+fn legacy_safe2(a: LegacySafe, b: LegacySafe) -> LegacySafe{
+    match (a,b){
+        (LegacySafe::LegacySafe, LegacySafe::LegacySafe) => LegacySafe::LegacySafe,
+        _ => LegacySafe::SegwitOnly
+    }
+}
+

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -2,7 +2,7 @@
 //! correctness or malleability.
 
 use super::{ErrorKind, Property, Error};
-use miniscript::astelem::AstElem;
+use Terminal;
 use script_num_size;
 
 /// Whether a fragment is OK to be used in non-segwit scripts
@@ -294,7 +294,7 @@ impl Property for ExtData {
     /// Compute the type of a fragment assuming all the children of
     /// Miniscript have been computed already.
     fn type_check<Pk, Pkh, C>(
-        fragment: &AstElem<Pk, Pkh>,
+        fragment: &Terminal<Pk, Pkh>,
         _child: C,
     ) -> Result<Self, Error<Pk, Pkh>>
         where
@@ -309,11 +309,11 @@ impl Property for ExtData {
             });
 
         let ret = match *fragment {
-            AstElem::True => Ok(Self::from_true()),
-            AstElem::False => Ok(Self::from_false()),
-            AstElem::Pk(..) => Ok(Self::from_pk()),
-            AstElem::PkH(..) => Ok(Self::from_pk_h()),
-            AstElem::ThreshM(k, ref pks) => {
+            Terminal::True => Ok(Self::from_true()),
+            Terminal::False => Ok(Self::from_false()),
+            Terminal::Pk(..) => Ok(Self::from_pk()),
+            Terminal::PkH(..) => Ok(Self::from_pk_h()),
+            Terminal::ThreshM(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -328,7 +328,7 @@ impl Property for ExtData {
                 }
                 Ok(Self::from_multi(k, pks.len()))
             },
-            AstElem::After(t) => {
+            Terminal::After(t) => {
                 if t == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -337,7 +337,7 @@ impl Property for ExtData {
                 }
                 Ok(Self::from_after(t))
             },
-            AstElem::Older(t) => {
+            Terminal::Older(t) => {
                 // FIXME check if t > 2^31 - 1
                 if t == 0 {
                     return Err(Error {
@@ -347,61 +347,61 @@ impl Property for ExtData {
                 }
                 Ok(Self::from_older(t))
             },
-            AstElem::Sha256(..) => Ok(Self::from_sha256()),
-            AstElem::Hash256(..) => Ok(Self::from_hash256()),
-            AstElem::Ripemd160(..) => Ok(Self::from_ripemd160()),
-            AstElem::Hash160(..) => Ok(Self::from_hash160()),
-            AstElem::Alt(ref sub) =>
+            Terminal::Sha256(..) => Ok(Self::from_sha256()),
+            Terminal::Hash256(..) => Ok(Self::from_hash256()),
+            Terminal::Ripemd160(..) => Ok(Self::from_ripemd160()),
+            Terminal::Hash160(..) => Ok(Self::from_hash160()),
+            Terminal::Alt(ref sub) =>
                 wrap_err(Self::cast_alt(sub.ext.clone())),
-            AstElem::Swap(ref sub) =>
+            Terminal::Swap(ref sub) =>
                 wrap_err(Self::cast_swap(sub.ext.clone())),
-            AstElem::Check(ref sub) =>
+            Terminal::Check(ref sub) =>
                 wrap_err(Self::cast_check(sub.ext.clone())),
-            AstElem::DupIf(ref sub) =>
+            Terminal::DupIf(ref sub) =>
                 wrap_err(Self::cast_dupif(sub.ext.clone())),
-            AstElem::Verify(ref sub) =>
+            Terminal::Verify(ref sub) =>
                 wrap_err(Self::cast_verify(sub.ext.clone())),
-            AstElem::NonZero(ref sub) =>
+            Terminal::NonZero(ref sub) =>
                 wrap_err(Self::cast_nonzero(sub.ext.clone())),
-            AstElem::ZeroNotEqual(ref sub) =>
+            Terminal::ZeroNotEqual(ref sub) =>
                 wrap_err(Self::cast_zeronotequal(sub.ext.clone())),
-            AstElem::AndB(ref l, ref r) => {
+            Terminal::AndB(ref l, ref r) => {
                 let ltype = l.ext.clone();
                 let rtype = r.ext.clone();
                 wrap_err(Self::and_b(ltype, rtype))
             },
-            AstElem::AndV(ref l, ref r) => {
+            Terminal::AndV(ref l, ref r) => {
                 let ltype = l.ext.clone();
                 let rtype = r.ext.clone();
                 wrap_err(Self::and_v(ltype, rtype))
             },
-            AstElem::OrB(ref l, ref r) => {
+            Terminal::OrB(ref l, ref r) => {
                 let ltype = l.ext.clone();
                 let rtype = r.ext.clone();
                 wrap_err(Self::or_b(ltype, rtype))
             },
-            AstElem::OrD(ref l, ref r) => {
+            Terminal::OrD(ref l, ref r) => {
                 let ltype = l.ext.clone();
                 let rtype = r.ext.clone();
                 wrap_err(Self::or_d(ltype, rtype))
             },
-            AstElem::OrC(ref l, ref r) => {
+            Terminal::OrC(ref l, ref r) => {
                 let ltype = l.ext.clone();
                 let rtype = r.ext.clone();
                 wrap_err(Self::or_c(ltype, rtype))
             },
-            AstElem::OrI(ref l, ref r) => {
+            Terminal::OrI(ref l, ref r) => {
                 let ltype = l.ext.clone();
                 let rtype = r.ext.clone();
                 wrap_err(Self::or_i(ltype, rtype))
             },
-            AstElem::AndOr(ref a, ref b, ref c) => {
+            Terminal::AndOr(ref a, ref b, ref c) => {
                 let atype = a.ext.clone();
                 let btype = b.ext.clone();
                 let ctype = c.ext.clone();
                 wrap_err(Self::and_or(atype, btype, ctype))
             },
-            AstElem::Thresh(k, ref subs) => {
+            Terminal::Thresh(k, ref subs) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -83,7 +83,7 @@ pub enum ErrorKind {
     },
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct Error<Pk: Clone, Pkh: Clone> {
     /// The fragment that failed typecheck
     pub fragment: Terminal<Pk, Pkh>,

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -18,7 +18,7 @@ pub mod extra_props;
 
 use std::{error, fmt};
 
-use miniscript::astelem::AstElem;
+use Terminal;
 pub use self::correctness::{Correctness, Base, Input};
 pub use self::malleability::{Dissat, Malleability};
 pub use self::extra_props::ExtData;
@@ -86,7 +86,7 @@ pub enum ErrorKind {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Error<Pk: Clone, Pkh: Clone> {
     /// The fragment that failed typecheck
-    pub fragment: AstElem<Pk, Pkh>,
+    pub fragment: Terminal<Pk, Pkh>,
     /// The reason that typechecking failed
     pub error: ErrorKind,
 }
@@ -364,7 +364,7 @@ pub trait Property: Sized {
     /// the types of its children, if available and relevant for the
     /// given fragment
     fn type_check<Pk, Pkh, C>(
-        fragment: &AstElem<Pk, Pkh>,
+        fragment: &Terminal<Pk, Pkh>,
         mut child: C,
     ) -> Result<Self, Error<Pk, Pkh>>
         where
@@ -382,11 +382,11 @@ pub trait Property: Sized {
             });
 
         let ret = match *fragment {
-            AstElem::True => Ok(Self::from_true()),
-            AstElem::False => Ok(Self::from_false()),
-            AstElem::Pk(..) => Ok(Self::from_pk()),
-            AstElem::PkH(..) => Ok(Self::from_pk_h()),
-            AstElem::ThreshM(k, ref pks) => {
+            Terminal::True => Ok(Self::from_true()),
+            Terminal::False => Ok(Self::from_false()),
+            Terminal::Pk(..) => Ok(Self::from_pk()),
+            Terminal::PkH(..) => Ok(Self::from_pk_h()),
+            Terminal::ThreshM(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -401,7 +401,7 @@ pub trait Property: Sized {
                 }
                 Ok(Self::from_multi(k, pks.len()))
             },
-            AstElem::After(t) => {
+            Terminal::After(t) => {
                 if t == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -410,7 +410,7 @@ pub trait Property: Sized {
                 }
                 Ok(Self::from_after(t))
             },
-            AstElem::Older(t) => {
+            Terminal::Older(t) => {
                 // FIXME check if t > 2^31 - 1
                 if t == 0 {
                     return Err(Error {
@@ -420,61 +420,61 @@ pub trait Property: Sized {
                 }
                 Ok(Self::from_older(t))
             },
-            AstElem::Sha256(..) => Ok(Self::from_sha256()),
-            AstElem::Hash256(..) => Ok(Self::from_hash256()),
-            AstElem::Ripemd160(..) => Ok(Self::from_ripemd160()),
-            AstElem::Hash160(..) => Ok(Self::from_hash160()),
-            AstElem::Alt(ref sub)
+            Terminal::Sha256(..) => Ok(Self::from_sha256()),
+            Terminal::Hash256(..) => Ok(Self::from_hash256()),
+            Terminal::Ripemd160(..) => Ok(Self::from_ripemd160()),
+            Terminal::Hash160(..) => Ok(Self::from_hash160()),
+            Terminal::Alt(ref sub)
             => wrap_err(Self::cast_alt(get_child(&sub.node, 0)?)),
-            AstElem::Swap(ref sub)
+            Terminal::Swap(ref sub)
             => wrap_err(Self::cast_swap(get_child(&sub.node, 0)?)),
-            AstElem::Check(ref sub)
+            Terminal::Check(ref sub)
             => wrap_err(Self::cast_check(get_child(&sub.node, 0)?)),
-            AstElem::DupIf(ref sub)
+            Terminal::DupIf(ref sub)
             => wrap_err(Self::cast_dupif(get_child(&sub.node, 0)?)),
-            AstElem::Verify(ref sub)
+            Terminal::Verify(ref sub)
             => wrap_err(Self::cast_verify(get_child(&sub.node, 0)?)),
-            AstElem::NonZero(ref sub)
+            Terminal::NonZero(ref sub)
             => wrap_err(Self::cast_nonzero(get_child(&sub.node, 0)?)),
-            AstElem::ZeroNotEqual(ref sub)
+            Terminal::ZeroNotEqual(ref sub)
             => wrap_err(Self::cast_zeronotequal(get_child(&sub.node, 0)?)),
-            AstElem::AndB(ref l, ref r) => {
+            Terminal::AndB(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::and_b(ltype, rtype))
             },
-            AstElem::AndV(ref l, ref r) => {
+            Terminal::AndV(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::and_v(ltype, rtype))
             },
-            AstElem::OrB(ref l, ref r) => {
+            Terminal::OrB(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::or_b(ltype, rtype))
             },
-            AstElem::OrD(ref l, ref r) => {
+            Terminal::OrD(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::or_d(ltype, rtype))
             },
-            AstElem::OrC(ref l, ref r) => {
+            Terminal::OrC(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::or_c(ltype, rtype))
             },
-            AstElem::OrI(ref l, ref r) => {
+            Terminal::OrI(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::or_i(ltype, rtype))
             },
-            AstElem::AndOr(ref a, ref b, ref c) => {
+            Terminal::AndOr(ref a, ref b, ref c) => {
                 let atype = get_child(&a.node, 0)?;
                 let btype = get_child(&b.node, 1)?;
                 let ctype = get_child(&c.node, 1)?;
                 wrap_err(Self::and_or(atype, btype, ctype))
             },
-            AstElem::Thresh(k, ref subs) => {
+            Terminal::Thresh(k, ref subs) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -767,7 +767,7 @@ impl Property for Type {
     /// Compute the type of a fragment assuming all the children of
     /// Miniscript have been computed already.
     fn type_check<Pk, Pkh, C>(
-        fragment: &AstElem<Pk, Pkh>,
+        fragment: &Terminal<Pk, Pkh>,
         _child: C,
     ) -> Result<Self, Error<Pk, Pkh>>
         where
@@ -782,11 +782,11 @@ impl Property for Type {
             });
 
         let ret = match *fragment {
-            AstElem::True => Ok(Self::from_true()),
-            AstElem::False => Ok(Self::from_false()),
-            AstElem::Pk(..) => Ok(Self::from_pk()),
-            AstElem::PkH(..) => Ok(Self::from_pk_h()),
-            AstElem::ThreshM(k, ref pks) => {
+            Terminal::True => Ok(Self::from_true()),
+            Terminal::False => Ok(Self::from_false()),
+            Terminal::Pk(..) => Ok(Self::from_pk()),
+            Terminal::PkH(..) => Ok(Self::from_pk_h()),
+            Terminal::ThreshM(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -801,7 +801,7 @@ impl Property for Type {
                 }
                 Ok(Self::from_multi(k, pks.len()))
             },
-            AstElem::After(t) => {
+            Terminal::After(t) => {
                 if t == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -810,7 +810,7 @@ impl Property for Type {
                 }
                 Ok(Self::from_after(t))
             },
-            AstElem::Older(t) => {
+            Terminal::Older(t) => {
                 // FIXME check if t > 2^31 - 1
                 if t == 0 {
                     return Err(Error {
@@ -820,61 +820,61 @@ impl Property for Type {
                 }
                 Ok(Self::from_older(t))
             },
-            AstElem::Sha256(..) => Ok(Self::from_sha256()),
-            AstElem::Hash256(..) => Ok(Self::from_hash256()),
-            AstElem::Ripemd160(..) => Ok(Self::from_ripemd160()),
-            AstElem::Hash160(..) => Ok(Self::from_hash160()),
-            AstElem::Alt(ref sub) =>
+            Terminal::Sha256(..) => Ok(Self::from_sha256()),
+            Terminal::Hash256(..) => Ok(Self::from_hash256()),
+            Terminal::Ripemd160(..) => Ok(Self::from_ripemd160()),
+            Terminal::Hash160(..) => Ok(Self::from_hash160()),
+            Terminal::Alt(ref sub) =>
                 wrap_err(Self::cast_alt(sub.ty.clone())),
-            AstElem::Swap(ref sub) =>
+            Terminal::Swap(ref sub) =>
                 wrap_err(Self::cast_swap(sub.ty.clone())),
-            AstElem::Check(ref sub) =>
+            Terminal::Check(ref sub) =>
                 wrap_err(Self::cast_check(sub.ty.clone())),
-            AstElem::DupIf(ref sub) =>
+            Terminal::DupIf(ref sub) =>
                 wrap_err(Self::cast_dupif(sub.ty.clone())),
-            AstElem::Verify(ref sub) =>
+            Terminal::Verify(ref sub) =>
                 wrap_err(Self::cast_verify(sub.ty.clone())),
-            AstElem::NonZero(ref sub) =>
+            Terminal::NonZero(ref sub) =>
                 wrap_err(Self::cast_nonzero(sub.ty.clone())),
-            AstElem::ZeroNotEqual(ref sub) =>
+            Terminal::ZeroNotEqual(ref sub) =>
                 wrap_err(Self::cast_zeronotequal(sub.ty.clone())),
-            AstElem::AndB(ref l, ref r) => {
+            Terminal::AndB(ref l, ref r) => {
                 let ltype = l.ty.clone();
                 let rtype = r.ty.clone();
                 wrap_err(Self::and_b(ltype, rtype))
             },
-            AstElem::AndV(ref l, ref r) => {
+            Terminal::AndV(ref l, ref r) => {
                 let ltype = l.ty.clone();
                 let rtype = r.ty.clone();
                 wrap_err(Self::and_v(ltype, rtype))
             },
-            AstElem::OrB(ref l, ref r) => {
+            Terminal::OrB(ref l, ref r) => {
                 let ltype = l.ty.clone();
                 let rtype = r.ty.clone();
                 wrap_err(Self::or_b(ltype, rtype))
             },
-            AstElem::OrD(ref l, ref r) => {
+            Terminal::OrD(ref l, ref r) => {
                 let ltype = l.ty.clone();
                 let rtype = r.ty.clone();
                 wrap_err(Self::or_d(ltype, rtype))
             },
-            AstElem::OrC(ref l, ref r) => {
+            Terminal::OrC(ref l, ref r) => {
                 let ltype = l.ty.clone();
                 let rtype = r.ty.clone();
                 wrap_err(Self::or_c(ltype, rtype))
             },
-            AstElem::OrI(ref l, ref r) => {
+            Terminal::OrI(ref l, ref r) => {
                 let ltype = l.ty.clone();
                 let rtype = r.ty.clone();
                 wrap_err(Self::or_i(ltype, rtype))
             },
-            AstElem::AndOr(ref a, ref b, ref c) => {
+            Terminal::AndOr(ref a, ref b, ref c) => {
                 let atype = a.ty.clone();
                 let btype = b.ty.clone();
                 let ctype = c.ty.clone();
                 wrap_err(Self::and_or(atype, btype, ctype))
             },
-            AstElem::Thresh(k, ref subs) => {
+            Terminal::Thresh(k, ref subs) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -22,7 +22,8 @@ use std::{cmp, f64, fmt};
 
 use policy::Concrete;
 use miniscript::astelem::AstElem;
-use miniscript::types::{self, Property};
+use miniscript::types::{self, Property, ErrorKind};
+use Miniscript;
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 struct OrdF64(f64);
@@ -36,13 +37,11 @@ impl Ord for OrdF64 {
 }
 
 #[derive(Copy, Clone, Debug)]
-struct ExtData {
+struct CompilerExtData {
     /// If this node is the direct child of a disjunction, this field must
     /// have the probability of its branch being taken. Otherwise it is ignored.
     /// All functions initialize it to `None`.
     branch_prob: Option<f64>,
-    /// The number of bytes needed to encode its scriptpubkey fragment
-    pk_cost: usize,
     /// The number of bytes needed to satisfy the fragment in segwit format
     /// (total length of all witness pushes, plus their own length prefixes)
     sat_cost: f64,
@@ -50,27 +49,9 @@ struct ExtData {
     /// (total length of all witness pushes, plus their own length prefixes)
     /// for fragments that can be dissatisfied without failing the script.
     dissat_cost: Option<f64>,
-    /// Whether this fragment can be verify-wrapped for free
-    has_verify_form: bool,
 }
 
-impl ExtData {
-    /// Compute a 1-dimensional cost, given a probability of satisfaction
-    /// and a probability of dissatisfaction; if `dissat_prob` is `None`
-    /// then it is assumed that dissatisfaction never occurs
-    fn cost_1d(&self, sat_prob: f64, dissat_prob: Option<f64>) -> f64 {
-        self.pk_cost as f64
-            + self.sat_cost * sat_prob
-            + match (dissat_prob, self.dissat_cost) {
-                (Some(prob), Some(cost)) => prob * cost,
-                (Some(_), None) => unreachable!(),
-                (None, Some(_)) => 0.0,
-                (None, None) => 0.0,
-            }
-    }
-}
-
-impl Property for ExtData {
+impl Property for CompilerExtData {
     fn from_true() -> Self {
         // only used in casts. should never be computed directly
         unreachable!();
@@ -82,38 +63,26 @@ impl Property for ExtData {
     }
 
     fn from_pk() -> Self {
-        ExtData {
+        CompilerExtData {
             branch_prob: None,
-            pk_cost: 34,
             sat_cost: 73.0,
             dissat_cost: Some(1.0),
-            has_verify_form: false,
         }
     }
 
     fn from_pk_h() -> Self {
-        ExtData {
+        CompilerExtData {
             branch_prob: None,
-            pk_cost: 24,
             sat_cost: 73.0 + 34.0,
             dissat_cost: Some(1.0 + 34.0),
-            has_verify_form: false,
         }
     }
 
-    fn from_multi(k: usize, n: usize) -> Self {
-        let num_cost = match(k > 16, n > 16) {
-            (true, true) => 4,
-            (false, true) => 3,
-            (true, false) => 3,
-            (false, false) => 2,
-        };
-        ExtData {
+    fn from_multi(k: usize, _n: usize) -> Self {
+        CompilerExtData {
             branch_prob: None,
-            pk_cost: num_cost + 34 * n + 1,
             sat_cost: 1.0 + 73.0 * k as f64,
             dissat_cost: Some(1.0 * (k + 1) as f64),
-            has_verify_form: true,
         }
     }
 
@@ -123,132 +92,106 @@ impl Property for ExtData {
     }
 
     fn from_sha256() -> Self {
-        ExtData {
+        CompilerExtData {
             branch_prob: None,
-            pk_cost: 33 + 6,
             sat_cost: 33.0,
             dissat_cost: Some(33.0),
-            has_verify_form: true,
         }
     }
 
     fn from_hash256() -> Self {
-        ExtData {
+        CompilerExtData {
             branch_prob: None,
-            pk_cost: 33 + 6,
             sat_cost: 33.0,
             dissat_cost: Some(33.0),
-            has_verify_form: true,
         }
     }
 
     fn from_ripemd160() -> Self {
-        ExtData {
+        CompilerExtData {
             branch_prob: None,
-            pk_cost: 21 + 6,
             sat_cost: 33.0,
             dissat_cost: Some(33.0),
-            has_verify_form: true,
         }
     }
 
     fn from_hash160() -> Self {
-        ExtData {
+        CompilerExtData {
             branch_prob: None,
-            pk_cost: 21 + 6,
             sat_cost: 33.0,
             dissat_cost: Some(33.0),
-            has_verify_form: true,
         }
     }
 
-    fn from_time(t: u32) -> Self {
-        ExtData {
+    fn from_time(_t: u32) -> Self {
+        CompilerExtData {
             branch_prob: None,
-            pk_cost: script_num_cost(t) + 1,
             sat_cost: 0.0,
             dissat_cost: None,
-            has_verify_form: false,
         }
     }
 
     fn cast_alt(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 2,
             sat_cost: self.sat_cost,
             dissat_cost: self.dissat_cost,
-            has_verify_form: false,
         })
     }
 
     fn cast_swap(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 1,
             sat_cost: self.sat_cost,
             dissat_cost: self.dissat_cost,
-            has_verify_form: self.has_verify_form,
         })
     }
 
     fn cast_check(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 1,
             sat_cost: self.sat_cost,
             dissat_cost: self.dissat_cost,
-            has_verify_form: true,
         })
     }
 
     fn cast_dupif(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 3,
             sat_cost: 2.0 + self.sat_cost,
             dissat_cost: Some(1.0),
-            has_verify_form: false,
         })
     }
 
     fn cast_verify(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + if self.has_verify_form { 0 } else { 1 },
             sat_cost: self.sat_cost,
             dissat_cost: None,
-            has_verify_form: false,
         })
     }
 
     fn cast_nonzero(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 4,
             sat_cost: self.sat_cost,
             dissat_cost: Some(1.0),
-            has_verify_form: false,
         })
     }
 
     fn cast_zeronotequal(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 1,
             sat_cost: self.sat_cost,
             dissat_cost: self.dissat_cost,
-            has_verify_form: false,
         })
     }
 
     fn cast_true(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 1,
             sat_cost: self.sat_cost,
             dissat_cost: None,
-            has_verify_form: false,
         })
     }
 
@@ -258,45 +201,37 @@ impl Property for ExtData {
     }
 
     fn cast_unlikely(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 4,
             sat_cost: 2.0 + self.sat_cost,
             dissat_cost: Some(1.0),
-            has_verify_form: false,
         })
     }
 
     fn cast_likely(self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: self.pk_cost + 4,
             sat_cost: 1.0 + self.sat_cost,
             dissat_cost: Some(2.0),
-            has_verify_form: false,
         })
     }
 
     fn and_b(left: Self, right: Self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: left.pk_cost + right.pk_cost + 1,
             sat_cost: left.sat_cost + right.sat_cost,
             dissat_cost: match (left.dissat_cost, right.dissat_cost) {
                 (Some(l), Some(r)) => Some(l + r),
                 _ => None,
             },
-            has_verify_form: false,
         })
     }
 
     fn and_v(left: Self, right: Self) -> Result<Self, types::ErrorKind> {
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: left.pk_cost + right.pk_cost,
             sat_cost: left.sat_cost + right.sat_cost,
             dissat_cost: None,
-            has_verify_form: right.has_verify_form,
         })
     }
 
@@ -305,13 +240,11 @@ impl Property for ExtData {
             .expect("BUG: left branch prob must be set for disjunctions");
         let rprob = r.branch_prob
             .expect("BUG: right branch prob must be set for disjunctions");
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: l.pk_cost + r.pk_cost + 1,
             sat_cost: lprob * (l.sat_cost + r.dissat_cost.unwrap())
                 + rprob * (r.sat_cost + l.dissat_cost.unwrap()),
             dissat_cost: Some(l.dissat_cost.unwrap() + r.dissat_cost.unwrap()),
-            has_verify_form: false,
         })
     }
 
@@ -320,13 +253,11 @@ impl Property for ExtData {
             .expect("BUG: left branch prob must be set for disjunctions");
         let rprob = r.branch_prob
             .expect("BUG: right branch prob must be set for disjunctions");
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: l.pk_cost + r.pk_cost + 3,
             sat_cost: lprob * l.sat_cost
                 + rprob * (r.sat_cost + l.dissat_cost.unwrap()),
             dissat_cost: r.dissat_cost.map(|rd| l.dissat_cost.unwrap() + rd),
-            has_verify_form: false,
         })
     }
 
@@ -335,13 +266,11 @@ impl Property for ExtData {
             .expect("BUG: left branch prob must be set for disjunctions");
         let rprob = r.branch_prob
             .expect("BUG: right branch prob must be set for disjunctions");
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: l.pk_cost + r.pk_cost + 2,
             sat_cost: lprob * l.sat_cost
                 + rprob * (r.sat_cost + l.dissat_cost.unwrap()),
             dissat_cost: None,
-            has_verify_form: false,
         })
     }
 
@@ -350,9 +279,8 @@ impl Property for ExtData {
             .expect("BUG: left branch prob must be set for disjunctions");
         let rprob = r.branch_prob
             .expect("BUG: right branch prob must be set for disjunctions");
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: l.pk_cost + r.pk_cost + 3,
             sat_cost: lprob * (2.0 + l.sat_cost)
                 + rprob * (1.0 + r.sat_cost),
             dissat_cost: if let Some(ldis) = l.dissat_cost {
@@ -362,7 +290,6 @@ impl Property for ExtData {
             } else {
                 None
             },
-            has_verify_form: false,
         })
     }
 
@@ -378,21 +305,17 @@ impl Property for ExtData {
     where S: FnMut(usize) -> Result<Self, types::ErrorKind>
     {
         let k_over_n = k as f64 / n as f64;
-        let mut pk_cost = 1 + script_num_cost(k as u32);
         let mut sat_cost = 0.0;
         let mut dissat_cost = 0.0;
         for i in 0..n {
             let sub = sub_ck(i)?;
-            pk_cost += sub.pk_cost;
             sat_cost += sub.sat_cost;
             dissat_cost += sub.dissat_cost.unwrap();
         }
-        Ok(ExtData {
+        Ok(CompilerExtData {
             branch_prob: None,
-            pk_cost: pk_cost,
             sat_cost: sat_cost * k_over_n,
             dissat_cost: Some(dissat_cost),
-            has_verify_form: false,
         })
     }
 }
@@ -400,24 +323,39 @@ impl Property for ExtData {
 /// Miniscript AST fragment with additional data needed by the compiler
 #[derive(Clone, Debug)]
 struct AstElemExt<Pk: Clone, Pkh: Clone> {
-    /// The actual AST fragment
-    ast: AstElem<Pk, Pkh>,
-    /// Its type as AST node
-    ast_type: types::Type,
+    /// The actual Miniscript fragment with type information
+    ms: Miniscript<Pk, Pkh>,
     /// Its "type" in terms of compiler data
-    ext_data: ExtData,
+    comp_ext_data: CompilerExtData,
+}
+
+impl CompilerExtData {
+    /// Compute a 1-dimensional cost, given a probability of satisfaction
+    /// and a probability of dissatisfaction; if `dissat_prob` is `None`
+    /// then it is assumed that dissatisfaction never occurs
+    fn cost_1d(&self, pk_cost: usize, sat_prob: f64, dissat_prob: Option<f64>) -> f64 {
+        pk_cost as f64
+            + self.sat_cost * sat_prob
+            + match (dissat_prob, self.dissat_cost) {
+            (Some(prob), Some(cost)) => prob * cost,
+            (Some(_), None) => unreachable!(),
+            (None, Some(_)) => 0.0,
+            (None, None) => 0.0,
+        }
+    }
 }
 
 impl<Pk, Pkh> AstElemExt<Pk, Pkh>
 where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug +  fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     fn terminal(ast: AstElem<Pk, Pkh>) -> AstElemExt<Pk, Pkh> {
         AstElemExt {
-            ast_type: types::Type::type_check(&ast, |_| None).unwrap(),
-            ext_data: ExtData::type_check(&ast, |_| None).unwrap(),
-            ast: ast,
+            comp_ext_data: CompilerExtData::type_check(&ast, |_| None).unwrap(),
+            ms: Miniscript::from_ast(ast)
+                .expect("Terminal creation must always succeed"),
+
         }
     }
 
@@ -426,28 +364,31 @@ where
         l: &AstElemExt<Pk, Pkh>,
         r: &AstElemExt<Pk, Pkh>,
     ) -> Result<AstElemExt<Pk, Pkh>, types::Error<Pk, Pkh>> {
-        let lookup_ast = |n| match n {
-            0 => Some(l.ast_type),
-            1 => Some(r.ast_type),
-            _ => unreachable!(),
-        };
         let lookup_ext = |n| match n {
-            0 => Some(l.ext_data),
-            1 => Some(r.ext_data),
+            0 => Some(l.comp_ext_data),
+            1 => Some(r.comp_ext_data),
             _ => unreachable!(),
         };
+        //Types and ExtData are already cached and stored in children. So, we can
+        //type_check without cache. For Compiler extra data, we supply a cache.
+        let ty = types::Type::type_check(&ast, |_| None)?;
+        let ext = types::ExtData::type_check(&ast, |_| None)?;
+        let comp_ext_data = CompilerExtData::type_check(&ast, lookup_ext)?;
         Ok(AstElemExt {
-            ast_type: types::Type::type_check(&ast, lookup_ast)?,
-            ext_data: ExtData::type_check(&ast, lookup_ext)?,
-            ast: ast,
+            ms: Miniscript{
+                ty: ty,
+                ext: ext,
+                node: ast,
+            },
+            comp_ext_data: comp_ext_data
         })
     }
 }
 
 impl<Pk, Pkh> AstElemExt<Pk, Pkh>
 where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     fn wrappings(
         &self,
@@ -460,61 +401,77 @@ where
 
 #[derive(Copy, Clone)]
 struct Cast<Pk, Pkh> {
-    ast: fn(Box<AstElem<Pk, Pkh>>) -> AstElem<Pk, Pkh>,
-    ast_type: fn(types::Type) -> Result<types::Type, types::ErrorKind>,
-    ext_data: fn(ExtData) -> Result<ExtData, types::ErrorKind>,
+    node: fn(Box<Miniscript<Pk, Pkh>>) -> AstElem<Pk, Pkh>,
+    ast_type: fn(types::Type) -> Result<types::Type, ErrorKind>,
+    ext_data: fn(types::ExtData) -> Result<types::ExtData, ErrorKind>,
+    comp_ext_data: fn(CompilerExtData) -> Result<CompilerExtData, types::ErrorKind>,
 }
 
 fn all_casts<Pk, Pkh>() -> [Cast<Pk, Pkh>; 9]
 where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     [
         Cast {
-            ast: AstElem::Alt,
+            node: AstElem::Alt,
             ast_type: types::Type::cast_alt,
-            ext_data: ExtData::cast_alt,
+            ext_data: types::ExtData::cast_alt,
+            comp_ext_data: CompilerExtData::cast_alt,
         },
         Cast {
-            ast: AstElem::Swap,
+            ext_data: types::ExtData::cast_swap,
+            node: AstElem::Swap,
             ast_type: types::Type::cast_swap,
-            ext_data: ExtData::cast_swap,
+            comp_ext_data: CompilerExtData::cast_swap,
         },
         Cast {
-            ast: AstElem::Check,
+            ext_data: types::ExtData::cast_check,
+            node: AstElem::Check,
             ast_type: types::Type::cast_check,
-            ext_data: ExtData::cast_check,
+            comp_ext_data: CompilerExtData::cast_check,
         },
         Cast {
-            ast: AstElem::DupIf,
+            ext_data: types::ExtData::cast_dupif,
+            node: AstElem::DupIf,
             ast_type: types::Type::cast_dupif,
-            ext_data: ExtData::cast_dupif,
+            comp_ext_data: CompilerExtData::cast_dupif,
         },
         Cast {
-            ast: AstElem::Verify,
+            ext_data: types::ExtData::cast_verify,
+            node: AstElem::Verify,
             ast_type: types::Type::cast_verify,
-            ext_data: ExtData::cast_verify,
+            comp_ext_data: CompilerExtData::cast_verify,
         },
         Cast {
-            ast: AstElem::NonZero,
+            ext_data: types::ExtData::cast_nonzero,
+            node: AstElem::NonZero,
             ast_type: types::Type::cast_nonzero,
-            ext_data: ExtData::cast_nonzero,
+            comp_ext_data: CompilerExtData::cast_nonzero,
         },
         Cast {
-            ast: |x| AstElem::AndV(x, Box::new(AstElem::True)),
+            ext_data: types::ExtData::cast_true,
+            node: |ms | AstElem::AndV(ms, Box::new(
+                Miniscript::from_ast(AstElem::True)
+                    .expect("True Miniscript creation"))),
             ast_type: types::Type::cast_true,
-            ext_data: ExtData::cast_true,
+            comp_ext_data: CompilerExtData::cast_true,
         },
         Cast {
-            ast: |x| AstElem::OrI(x, Box::new(AstElem::False)),
+            ext_data: types::ExtData::cast_unlikely,
+            node: |ms| AstElem::OrI(ms, Box::new(
+                Miniscript::from_ast(AstElem::False)
+                    .expect("False Miniscript creation"))),
             ast_type: types::Type::cast_unlikely,
-            ext_data: ExtData::cast_unlikely,
+            comp_ext_data: CompilerExtData::cast_unlikely,
         },
         Cast {
-            ast: |x| AstElem::OrI(Box::new(AstElem::False), x),
+            ext_data: types::ExtData::cast_likely,
+            node: |ms| AstElem::OrI(Box::new(
+                Miniscript::from_ast(AstElem::False)
+                    .expect("False Miniscript creation")), ms),
             ast_type: types::Type::cast_likely,
-            ext_data: ExtData::cast_likely,
+            comp_ext_data: CompilerExtData::cast_likely,
         },
     ]
 }
@@ -537,8 +494,8 @@ struct WrappingIter<Pk: Clone, Pkh: Clone> {
 
 impl<Pk, Pkh> WrappingIter<Pk, Pkh>
 where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     fn new(
         elem: &AstElemExt<Pk, Pkh>,
@@ -557,8 +514,8 @@ where
 
 impl<Pk, Pkh> Iterator for WrappingIter<Pk, Pkh>
 where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     type Item = AstElemExt<Pk, Pkh>;
 
@@ -574,28 +531,33 @@ where
 
         // Try applying a new cast
         for i in 0..all_casts.len() {
-            if let Ok(ast_type) = (all_casts[i].ast_type)(current.ast_type) {
-                if !ast_type.mall.non_malleable {
+            if let Ok(ms_type) = (all_casts[i].ast_type)(current.ms.ty) {
+                if !ms_type.mall.non_malleable {
                     continue;
                 }
 
-                let ext_data = (all_casts[i].ext_data)(current.ext_data)
+                let comp_ext_data = (all_casts[i].comp_ext_data)(current.comp_ext_data)
+                    .expect("if AST typeck passes then compiler ext typeck must");
+                let ms_ext_data = (all_casts[i].ext_data)(current.ms.ext)
                     .expect("if AST typeck passes then ext typeck must");
 
-                let cost = ext_data.cost_1d(self.sat_prob, self.dissat_prob);
+                let cost = comp_ext_data.cost_1d(ms_ext_data.pk_cost, self.sat_prob, self.dissat_prob);
                 let old_best_cost = self
                     .visited_types
-                    .get(&ast_type)
+                    .get(&ms_type)
                     .map(|x| *x)
                     .unwrap_or(f64::INFINITY);
 
                 if cost < old_best_cost {
                     let new_ext = AstElemExt {
-                        ast: (all_casts[i].ast)(Box::new(current.ast.clone())),
-                        ast_type: ast_type,
-                        ext_data: ext_data,
+                        ms: Miniscript{
+                            node: (all_casts[i].node)(Box::new(current.ms.clone())),
+                            ty: ms_type,
+                            ext: ms_ext_data,
+                        },
+                        comp_ext_data: comp_ext_data,
                     };
-                    self.visited_types.insert(ast_type, cost);
+                    self.visited_types.insert(ms_type, cost);
                     self.cast_stack.push((i, new_ext));
                     return self.next();
                 }
@@ -609,37 +571,23 @@ where
     }
 }
 
-fn script_num_cost(n: u32) -> usize {
-    if n <= 16 {
-        1
-    } else if n < 0x80 {
-        2
-    } else if n < 0x8000 {
-        3
-    } else if n < 0x800000 {
-        4
-    } else {
-        5
-    }
-}
-
 fn insert_best<Pk, Pkh>(
     map: &mut HashMap<types::Type, AstElemExt<Pk, Pkh>>,
     elem: AstElemExt<Pk, Pkh>,
     sat_prob: f64,
     dissat_prob: Option<f64>,
 ) where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
-    match map.entry(elem.ast_type) {
+    match map.entry(elem.ms.ty) {
         hash_map::Entry::Vacant(x) => {
             x.insert(elem);
         },
         hash_map::Entry::Occupied(mut x) => {
             let existing = x.get_mut();
-            if elem.ext_data.cost_1d(sat_prob, dissat_prob)
-                < existing.ext_data.cost_1d(sat_prob, dissat_prob)
+            if elem.comp_ext_data.cost_1d(elem.ms.ext.pk_cost, sat_prob, dissat_prob)
+                < existing.comp_ext_data.cost_1d(existing.ms.ext.pk_cost, sat_prob, dissat_prob)
             {
                 *existing = elem;
             }
@@ -653,8 +601,8 @@ fn insert_best_wrapped<Pk: Clone, Pkh: Clone>(
     sat_prob: f64,
     dissat_prob: Option<f64>,
 ) where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     for wrapped in data.wrappings(sat_prob, dissat_prob) {
         insert_best(
@@ -671,8 +619,8 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
     sat_prob: f64,
     dissat_prob: Option<f64>,
 ) -> HashMap<types::Type, AstElemExt<Pk, Pkh>> where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     let mut ret = HashMap::new();
     match *policy {
@@ -733,7 +681,7 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
             let left = best_compilations(&subs[0], sat_prob, dissat_prob);
             let right = best_compilations(&subs[1], sat_prob, dissat_prob);
             for l in left.values() {
-                let lbox = Box::new(l.ast.clone());
+                let lbox = Box::new(l.ms.clone());
                 for r in right.values() {
                     #[derive(Clone)]
                     struct Try<'l, 'r, Pk: Clone + 'l + 'r, Pkh: Clone + 'l + 'r> {
@@ -756,7 +704,7 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
                         }
                     }
 
-                    let rbox = Box::new(r.ast.clone());
+                    let rbox = Box::new(r.ms.clone());
                     let mut tries = [
                         Some(AstElem::AndB(lbox.clone(), rbox.clone())),
                         Some(AstElem::AndV(lbox.clone(), rbox.clone())),
@@ -804,7 +752,7 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
             let lweight = subs[0].0 as f64 / total;
             let rweight = subs[1].0 as f64 / total;
             for l in left.values_mut() {
-                let lbox = Box::new(l.ast.clone());
+                let lbox = Box::new(l.ms.clone());
                 for r in right.values_mut() {
                     struct Try<'l, 'r, Pk: Clone + 'l + 'r, Pkh: Clone + 'l + 'r> {
                         left: &'l AstElemExt<Pk, Pkh>,
@@ -828,7 +776,7 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
                         }
                     }
 
-                    let rbox = Box::new(r.ast.clone());
+                    let rbox = Box::new(r.ms.clone());
                     let mut tries = [
                         Some(AstElem::OrB(lbox.clone(), rbox.clone())),
                         Some(AstElem::OrD(lbox.clone(), rbox.clone())),
@@ -836,8 +784,8 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
                         Some(AstElem::OrI(lbox.clone(), rbox.clone())),
                     ];
                     for opt in &mut tries {
-                        l.ext_data.branch_prob = Some(lweight);
-                        r.ext_data.branch_prob = Some(rweight);
+                        l.comp_ext_data.branch_prob = Some(lweight);
+                        r.comp_ext_data.branch_prob = Some(rweight);
                         let d = Try {
                             left: l,
                             right: r,
@@ -875,7 +823,6 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
             let k_over_n = k as f64 / n as f64;
 
             let mut sub_ast = Vec::with_capacity(n);
-            let mut sub_ast_type = Vec::with_capacity(n);
             let mut sub_ext_data = Vec::with_capacity(n);
 
             for (i, ast) in subs.iter().enumerate() {
@@ -886,17 +833,15 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
                 } else {
                     best_w(ast, sp, dp)
                 };
-                sub_ast.push(best_ext.ast);
-                sub_ast_type.push(best_ext.ast_type);
-                sub_ext_data.push(best_ext.ext_data);
+                sub_ast.push(best_ext.ms);
+                sub_ext_data.push(best_ext.comp_ext_data);
             }
 
             let ast = AstElem::Thresh(k, sub_ast);
             let ast_ext = AstElemExt {
-                ast: ast,
-                ast_type: types::Type::threshold(k, n, |i| Ok(sub_ast_type[i]))
+                ms: Miniscript::from_ast(ast)
                     .expect("threshold subs, which we just compiled, typeck"),
-                ext_data: ExtData::threshold(k, n, |i| Ok(sub_ext_data[i]))
+                comp_ext_data: CompilerExtData::threshold(k, n, |i| Ok(sub_ext_data[i]))
                     .expect("threshold subs, which we just compiled, typeck"),
             };
             insert_best_wrapped(&mut ret, ast_ext, sat_prob, dissat_prob);
@@ -924,11 +869,11 @@ fn best_compilations<Pk: Clone, Pkh: Clone>(
 
 pub fn best_compilation<Pk, Pkh>(
     policy: &Concrete<Pk, Pkh>,
-) -> AstElem<Pk, Pkh> where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+) -> Miniscript<Pk, Pkh> where
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
-    best_t(policy, 1.0, None).ast
+    best_t(policy, 1.0, None).ms
 }
 
 fn best_t<Pk, Pkh>(
@@ -936,14 +881,14 @@ fn best_t<Pk, Pkh>(
     sat_prob: f64,
     dissat_prob: Option<f64>,
 ) -> AstElemExt<Pk, Pkh> where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     best_compilations(policy, 1.0, None)
         .into_iter()
         .filter(|&(key, _)| key.corr.base == types::Base::B)
         .map(|(_, val)| val)
-        .min_by_key(|ext| OrdF64(ext.ext_data.cost_1d(sat_prob, dissat_prob)))
+        .min_by_key(|ext| OrdF64(ext.comp_ext_data.cost_1d( ext.ms.ext.pk_cost, sat_prob, dissat_prob)))
         .unwrap()
 }
 
@@ -952,17 +897,17 @@ fn best_e<Pk, Pkh>(
     sat_prob: f64,
     dissat_prob: Option<f64>,
 ) -> AstElemExt<Pk, Pkh> where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     best_compilations(policy, sat_prob, dissat_prob)
         .into_iter()
         .filter(|&(ref key, ref val)| key.corr.base == types::Base::B
                 && key.corr.unit
-                && val.ast_type.mall.dissat == types::Dissat::Unique
+                && val.ms.ty.mall.dissat == types::Dissat::Unique
         )
         .map(|(_, val)| val)
-        .min_by_key(|ext| OrdF64(ext.ext_data.cost_1d(sat_prob, dissat_prob)))
+        .min_by_key(|ext| OrdF64(ext.comp_ext_data.cost_1d( ext.ms.ext.pk_cost, sat_prob, dissat_prob)))
         .unwrap()
 }
 
@@ -971,17 +916,17 @@ fn best_w<Pk, Pkh>(
     sat_prob: f64,
     dissat_prob: Option<f64>,
 ) -> AstElemExt<Pk, Pkh> where
-    Pk: Clone + fmt::Debug,
-    Pkh: Clone + fmt::Debug,
+    Pk: Clone + fmt::Debug + fmt::Display,
+    Pkh: Clone + fmt::Debug + fmt::Display,
 {
     best_compilations(policy, sat_prob, dissat_prob)
         .into_iter()
         .filter(|&(ref key, ref val)| key.corr.base == types::Base::W
                 && key.corr.unit
-                && val.ast_type.mall.dissat == types::Dissat::Unique
+                && val.ms.ty.mall.dissat == types::Dissat::Unique
         )
         .map(|(_, val)| val)
-        .min_by_key(|ext| OrdF64(ext.ext_data.cost_1d(sat_prob, dissat_prob)))
+        .min_by_key(|ext| OrdF64(ext.comp_ext_data.cost_1d( ext.ms.ext.pk_cost, sat_prob, dissat_prob)))
         .unwrap()
 }
 
@@ -1051,10 +996,10 @@ mod tests {
             .expect("parsing");
         let compilation = best_t(&policy, 1.0, None);
 
-        assert_eq!(compilation.ext_data.cost_1d(1.0, None), 108.0 + 73.578125);
+        assert_eq!(compilation.comp_ext_data.cost_1d(compilation.ms.ext.pk_cost, 1.0, None), 108.0 + 73.578125);
         assert_eq!(
             policy.into_lift().sorted(),
-            compilation.ast.into_lift().sorted()
+            compilation.ms.into_lift().sorted()
         );
 
         /*
@@ -1068,10 +1013,10 @@ mod tests {
         ).expect("parsing");
         let compilation = best_t(&policy, 1.0, None);
 
-        assert_eq!(compilation.ext_data.cost_1d(1.0, None), 480.0 + 283.71484375);
+        assert_eq!(compilation.comp_ext_data.cost_1d(compilation.ms.ext.pk_cost, 1.0, None), 480.0 + 282.71484375);
         assert_eq!(
             policy.into_lift().sorted(),
-            compilation.ast.into_lift().sorted()
+            compilation.ms.into_lift().sorted()
         );
     }
 

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1095,10 +1095,8 @@ mod tests {
         );
 
         // CSV reordering trick
-        let policy: BPolicy = Concrete::And(vec![
-            Concrete::After(10000),
-            Concrete::Threshold(2, key_pol[5..8].to_owned()),
-        ]);
+        let policy: BPolicy = policy_str!("and(after(10000),thresh(2,pk({}),pk({}),pk({})))",
+        keys[5], keys[6], keys[7] );
         let desc = policy.compile();
         assert_eq!(
             desc.encode(),

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -56,7 +56,9 @@ pub enum Policy<Pk, Pkh> {
     Threshold(usize, Vec<Policy<Pk, Pkh>>),
 }
 
-impl<Pk: Clone + fmt::Debug, Pkh: Clone + fmt::Debug> Policy<Pk, Pkh> {
+impl<Pk, Pkh> Policy<Pk, Pkh>
+    where Pk:  Clone + fmt::Debug + fmt::Display, Pkh: Clone + fmt::Debug + fmt::Display
+{
     /// Compile the descriptor into an optimized `Miniscript` representation
     #[cfg(feature="compiler")]
     pub fn compile(&self) -> Miniscript<Pk, Pkh> {

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -28,8 +28,8 @@ pub mod semantic;
 pub mod compiler;
 
 use descriptor::Descriptor;
-use miniscript::astelem::AstElem;
 use miniscript::Miniscript;
+use Terminal;
 
 pub use self::concrete::Policy as Concrete;
 /// Semantic policies are "abstract" policies elsewhere; but we
@@ -49,43 +49,43 @@ impl<Pk, Pkh> Liftable<Pk, Pkh> for Miniscript<Pk, Pkh> {
     }
 }
 
-impl<Pk, Pkh> Liftable<Pk, Pkh> for AstElem<Pk, Pkh> {
+impl<Pk, Pkh> Liftable<Pk, Pkh> for Terminal<Pk, Pkh> {
     fn into_lift(self) -> Semantic<Pk, Pkh> {
         match self {
-            AstElem::Pk(pk) => Semantic::Key(pk),
-            AstElem::PkH(pkh) => Semantic::KeyHash(pkh),
-            AstElem::After(t) => Semantic::After(t),
-            AstElem::Older(t) => Semantic::Older(t),
-            AstElem::Sha256(h) => Semantic::Sha256(h),
-            AstElem::Hash256(h) => Semantic::Hash256(h),
-            AstElem::Ripemd160(h) => Semantic::Ripemd160(h),
-            AstElem::Hash160(h) => Semantic::Hash160(h),
-            AstElem::True => Semantic::Trivial,
-            AstElem::False => Semantic::Unsatisfiable,
-            AstElem::Alt(sub)
-                | AstElem::Swap(sub)
-                | AstElem::Check(sub)
-                | AstElem::DupIf(sub)
-                | AstElem::Verify(sub)
-                | AstElem::NonZero(sub)
-                | AstElem::ZeroNotEqual(sub) => sub.node.into_lift(),
-            AstElem::AndV(left, right)
-                | AstElem::AndB(left, right)
+            Terminal::Pk(pk) => Semantic::Key(pk),
+            Terminal::PkH(pkh) => Semantic::KeyHash(pkh),
+            Terminal::After(t) => Semantic::After(t),
+            Terminal::Older(t) => Semantic::Older(t),
+            Terminal::Sha256(h) => Semantic::Sha256(h),
+            Terminal::Hash256(h) => Semantic::Hash256(h),
+            Terminal::Ripemd160(h) => Semantic::Ripemd160(h),
+            Terminal::Hash160(h) => Semantic::Hash160(h),
+            Terminal::True => Semantic::Trivial,
+            Terminal::False => Semantic::Unsatisfiable,
+            Terminal::Alt(sub)
+                | Terminal::Swap(sub)
+                | Terminal::Check(sub)
+                | Terminal::DupIf(sub)
+                | Terminal::Verify(sub)
+                | Terminal::NonZero(sub)
+                | Terminal::ZeroNotEqual(sub) => sub.node.into_lift(),
+            Terminal::AndV(left, right)
+                | Terminal::AndB(left, right)
                 => Semantic::And(vec![left.node.into_lift(), right.node.into_lift()]),
-            AstElem::AndOr(a, b, c) => Semantic::Or(vec![
+            Terminal::AndOr(a, b, c) => Semantic::Or(vec![
                 Semantic::And(vec![a.node.into_lift(), c.node.into_lift()]),
                 b.node.into_lift(),
             ]),
-            AstElem::OrB(left, right)
-                | AstElem::OrD(left, right)
-                | AstElem::OrC(left, right)
-                | AstElem::OrI(left, right)
+            Terminal::OrB(left, right)
+                | Terminal::OrD(left, right)
+                | Terminal::OrC(left, right)
+                | Terminal::OrI(left, right)
                 => Semantic::Or(vec![left.node.into_lift(), right.node.into_lift()]),
-            AstElem::Thresh(k, subs) => Semantic::Threshold(
+            Terminal::Thresh(k, subs) => Semantic::Threshold(
                 k,
                 subs.into_iter().map(|s| s.node.into_lift()).collect(),
             ),
-            AstElem::ThreshM(k, keys) => Semantic::Threshold(
+            Terminal::ThreshM(k, keys) => Semantic::Threshold(
                 k,
                 keys.into_iter().map(|k| Semantic::Key(k)).collect(),
             ),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -68,22 +68,22 @@ impl<Pk, Pkh> Liftable<Pk, Pkh> for AstElem<Pk, Pkh> {
                 | AstElem::DupIf(sub)
                 | AstElem::Verify(sub)
                 | AstElem::NonZero(sub)
-                | AstElem::ZeroNotEqual(sub) => sub.into_lift(),
+                | AstElem::ZeroNotEqual(sub) => sub.node.into_lift(),
             AstElem::AndV(left, right)
                 | AstElem::AndB(left, right)
-                => Semantic::And(vec![left.into_lift(), right.into_lift()]),
+                => Semantic::And(vec![left.node.into_lift(), right.node.into_lift()]),
             AstElem::AndOr(a, b, c) => Semantic::Or(vec![
-                Semantic::And(vec![a.into_lift(), c.into_lift()]),
-                b.into_lift(),
+                Semantic::And(vec![a.node.into_lift(), c.node.into_lift()]),
+                b.node.into_lift(),
             ]),
             AstElem::OrB(left, right)
                 | AstElem::OrD(left, right)
                 | AstElem::OrC(left, right)
                 | AstElem::OrI(left, right)
-                => Semantic::Or(vec![left.into_lift(), right.into_lift()]),
+                => Semantic::Or(vec![left.node.into_lift(), right.node.into_lift()]),
             AstElem::Thresh(k, subs) => Semantic::Threshold(
                 k,
-                subs.into_iter().map(|s| s.into_lift()).collect(),
+                subs.into_iter().map(|s| s.node.into_lift()).collect(),
             ),
             AstElem::ThreshM(k, keys) => Semantic::Threshold(
                 k,
@@ -99,7 +99,7 @@ impl<Pk, Pkh> Liftable<Pk, Pkh> for Descriptor<Pk, Pkh> {
             Descriptor::Bare(d)
                 | Descriptor::Sh(d)
                 | Descriptor::Wsh(d)
-                | Descriptor::ShWsh(d) => d.into_lift(),
+                | Descriptor::ShWsh(d) => d.node.into_lift(),
             Descriptor::Pk(p)
                 | Descriptor::Pkh(p)
                 | Descriptor::Wpkh(p)


### PR DESCRIPTION
-Change miniscript to save type information
-Change tests to use string inputs instead of `decode::Terminal`(previsouly `asterm::AstElem`)