### PR TITLE
 Added PubkeyTrait and changed Miniscript/Terminals to a single generic

### DIFF
--- a/fuzz/fuzz_targets/compile_descriptor.rs
+++ b/fuzz/fuzz_targets/compile_descriptor.rs
@@ -1,12 +1,12 @@
 extern crate miniscript;
 
-use miniscript::{policy, DummyKey, DummyKeyHash, Miniscript};
+use miniscript::{policy, DummyKey, Miniscript};
 use policy::Liftable;
 
 use std::str::FromStr;
 
-type DummyScript = Miniscript<DummyKey, DummyKeyHash>;
-type DummyPolicy = policy::Concrete<DummyKey, DummyKeyHash>;
+type DummyScript = Miniscript<DummyKey>;
+type DummyPolicy = policy::Concrete<DummyKey>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/roundtrip_concrete.rs
+++ b/fuzz/fuzz_targets/roundtrip_concrete.rs
@@ -2,9 +2,9 @@
 extern crate miniscript;
 
 use std::str::FromStr;
-use miniscript::{policy, DummyKey, DummyKeyHash};
+use miniscript::{policy, DummyKey};
 
-type DummyPolicy = policy::Concrete::<DummyKey, DummyKeyHash>;
+type DummyPolicy = policy::Concrete<DummyKey>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/roundtrip_descriptor.rs
+++ b/fuzz/fuzz_targets/roundtrip_descriptor.rs
@@ -1,13 +1,13 @@
 
 extern crate miniscript;
 
-use miniscript::{Descriptor, DummyKey, DummyKeyHash};
+use miniscript::{Descriptor, DummyKey};
 
 use std::str::FromStr;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
-    if let Ok(desc) = Descriptor::<DummyKey, DummyKeyHash>::from_str(&s) {
+    if let Ok(desc) = Descriptor::<DummyKey>::from_str(&s) {
         let output = desc.to_string();
         assert_eq!(s, output);
     }

--- a/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
@@ -4,12 +4,12 @@ extern crate miniscript;
 
 use std::str::FromStr;
 
-use miniscript::{DummyKey, DummyKeyHash};
+use miniscript::{DummyKey};
 use miniscript::Miniscript;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
-    if let Ok(desc) = Miniscript::<DummyKey, DummyKeyHash>::from_str(&s) {
+    if let Ok(desc) = Miniscript::<DummyKey>::from_str(&s) {
         let output = desc.to_string();
         assert_eq!(s, output);
     }

--- a/fuzz/fuzz_targets/roundtrip_policy.rs
+++ b/fuzz/fuzz_targets/roundtrip_policy.rs
@@ -2,10 +2,10 @@
 extern crate miniscript;
 
 use std::str::FromStr;
-use miniscript::{policy, DummyKey, DummyKeyHash};
+use miniscript::{policy, DummyKey};
 
-type DummyPolicy = policy::Concrete::<DummyKey, DummyKeyHash>;
-type DummyPolicy2 = policy::Semantic::<DummyKey, DummyKeyHash>;
+type DummyPolicy = policy::Concrete<DummyKey>;
+type DummyPolicy2 = policy::Semantic<DummyKey>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/roundtrip_semantic.rs
+++ b/fuzz/fuzz_targets/roundtrip_semantic.rs
@@ -2,9 +2,9 @@
 extern crate miniscript;
 
 use std::str::FromStr;
-use miniscript::{policy, DummyKey, DummyKeyHash};
+use miniscript::{policy, DummyKey};
 
-type DummyPolicy = policy::Semantic<DummyKey, DummyKeyHash>;
+type DummyPolicy = policy::Semantic<DummyKey>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl fmt::Display for DummyKey {
 
 impl ToPublicKey for DummyKey {
     fn to_public_key(&self) -> bitcoin::PublicKey {
-        bitcoin::PublicKey::from_str("020102030405060708010203040506070801020304050607080102030405060708").unwrap()
+        bitcoin::PublicKey::from_str("0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352").unwrap()
     }
 }
 
@@ -235,7 +235,7 @@ impl fmt::Display for DummyKeyHash {
 impl ToHash160 for DummyKeyHash{
 
     fn to_hash160(&self) -> hash160::Hash{
-        hash160::Hash::from_str("").unwrap()
+        hash160::Hash::from_str("f54a5851e9372b87810a8e60cdd2e7cfd80b6e31").unwrap()
     }
 }
 

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -4,6 +4,7 @@
 use super::{ErrorKind, Property, Error};
 use Terminal;
 use script_num_size;
+use MiniscriptKey;
 
 /// Whether a fragment is OK to be used in non-segwit scripts
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
@@ -293,14 +294,13 @@ impl Property for ExtData {
 
     /// Compute the type of a fragment assuming all the children of
     /// Miniscript have been computed already.
-    fn type_check<Pk, Pkh, C>(
-        fragment: &Terminal<Pk, Pkh>,
+    fn type_check<Pk, C>(
+        fragment: &Terminal<Pk>,
         _child: C,
-    ) -> Result<Self, Error<Pk, Pkh>>
+    ) -> Result<Self, Error<Pk>>
         where
             C: FnMut(usize) -> Option<Self>,
-            Pk: Clone,
-            Pkh: Clone,
+            Pk: MiniscriptKey,
     {
         let wrap_err = |result: Result<Self, ErrorKind>| result
             .map_err(|kind| Error {

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -957,8 +957,8 @@ mod tests {
 
         let policy = DummyPolicy::from_str("pk()").expect("parse");
         let miniscript = policy.compile();
-        assert_eq!(policy.into_lift(), Semantic::Key(DummyKey));
-        assert_eq!(miniscript.into_lift(), Semantic::Key(DummyKey));
+        assert_eq!(policy.into_lift(), Semantic::KeyHash(DummyKeyHash));
+        assert_eq!(miniscript.into_lift(), Semantic::KeyHash(DummyKeyHash));
 
         let policy = DummyPolicy::from_str("pkh()").expect("parse");
         let miniscript = policy.compile();

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -56,7 +56,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Miniscript<Pk> {
 impl<Pk: MiniscriptKey> Liftable<Pk> for Terminal<Pk> {
     fn into_lift(self) -> Semantic<Pk> {
         match self {
-            Terminal::Pk(pk) => Semantic::Key(pk),
+            Terminal::Pk(pk) => Semantic::KeyHash(pk.to_pubkeyhash()),
             Terminal::PkH(pkh) => Semantic::KeyHash(pkh),
             Terminal::After(t) => Semantic::After(t),
             Terminal::Older(t) => Semantic::Older(t),
@@ -91,7 +91,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Terminal<Pk> {
             ),
             Terminal::ThreshM(k, keys) => Semantic::Threshold(
                 k,
-                keys.into_iter().map(|k| Semantic::Key(k)).collect(),
+                keys.into_iter().map(|k| Semantic::KeyHash(k.to_pubkeyhash())).collect(),
             ),
         }.normalized()
     }
@@ -107,7 +107,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Descriptor<Pk> {
             Descriptor::Pk(p)
                 | Descriptor::Pkh(p)
                 | Descriptor::Wpkh(p)
-                | Descriptor::ShWpkh(p) => Semantic::Key(p),
+                | Descriptor::ShWpkh(p) => Semantic::KeyHash(p.to_pubkeyhash()),
         }
     }
 }
@@ -121,7 +121,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Semantic<Pk> {
 impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
     fn into_lift(self) -> Semantic<Pk> {
         match self {
-            Concrete::Key(pk) => Semantic::Key(pk),
+            Concrete::Key(pk) => Semantic::KeyHash(pk.to_pubkeyhash()),
             Concrete::KeyHash(pkh) => Semantic::KeyHash(pkh),
             Concrete::After(t) => Semantic::After(t),
             Concrete::Older(t) => Semantic::Older(t),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -35,22 +35,26 @@ pub use self::concrete::Policy as Concrete;
 /// Semantic policies are "abstract" policies elsewhere; but we
 /// avoid this word because it is a reserved keyword in Rust
 pub use self::semantic::Policy as Semantic;
+use MiniscriptKey;
 
 /// Trait describing script representations which can be lifted into
-/// an abstract policy, by discarding information
-pub trait Liftable<Pk, Pkh> {
+/// an abstract policy, by discarding information.
+/// After Lifting all policies are converted into `KeyHash(Pk::HasH)` to
+/// maintain the following invariant:
+/// `Lift(Concrete) == Concrete -> Miniscript -> Script -> Miniscript -> Semantic`
+pub trait Liftable<Pk: MiniscriptKey> {
     /// Convert the object into an abstract policy
-    fn into_lift(self) -> Semantic<Pk, Pkh>;
+    fn into_lift(self) -> Semantic<Pk>;
 }
 
-impl<Pk, Pkh> Liftable<Pk, Pkh> for Miniscript<Pk, Pkh> {
-    fn into_lift(self) -> Semantic<Pk, Pkh> {
+impl<Pk: MiniscriptKey> Liftable<Pk> for Miniscript<Pk> {
+    fn into_lift(self) -> Semantic<Pk> {
         self.into_inner().into_lift()
     }
 }
 
-impl<Pk, Pkh> Liftable<Pk, Pkh> for Terminal<Pk, Pkh> {
-    fn into_lift(self) -> Semantic<Pk, Pkh> {
+impl<Pk: MiniscriptKey> Liftable<Pk> for Terminal<Pk> {
+    fn into_lift(self) -> Semantic<Pk> {
         match self {
             Terminal::Pk(pk) => Semantic::Key(pk),
             Terminal::PkH(pkh) => Semantic::KeyHash(pkh),
@@ -93,8 +97,8 @@ impl<Pk, Pkh> Liftable<Pk, Pkh> for Terminal<Pk, Pkh> {
     }
 }
 
-impl<Pk, Pkh> Liftable<Pk, Pkh> for Descriptor<Pk, Pkh> {
-    fn into_lift(self) -> Semantic<Pk, Pkh> {
+impl<Pk: MiniscriptKey> Liftable<Pk> for Descriptor<Pk> {
+    fn into_lift(self) -> Semantic<Pk> {
         match self {
             Descriptor::Bare(d)
                 | Descriptor::Sh(d)
@@ -108,14 +112,14 @@ impl<Pk, Pkh> Liftable<Pk, Pkh> for Descriptor<Pk, Pkh> {
     }
 }
 
-impl<Pk, Pkh> Liftable<Pk, Pkh> for Semantic<Pk, Pkh> {
-    fn into_lift(self) -> Semantic<Pk, Pkh> {
+impl<Pk: MiniscriptKey> Liftable<Pk> for Semantic<Pk> {
+    fn into_lift(self) -> Semantic<Pk> {
         self
     }
 }
 
-impl<Pk, Pkh> Liftable<Pk, Pkh> for Concrete<Pk, Pkh> {
-    fn into_lift(self) -> Semantic<Pk, Pkh> {
+impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
+    fn into_lift(self) -> Semantic<Pk> {
         match self {
             Concrete::Key(pk) => Semantic::Key(pk),
             Concrete::KeyHash(pkh) => Semantic::KeyHash(pkh),

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -100,7 +100,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl<Pkh> Satisfier<bitcoin::PublicKey, Pkh> for psbt::Input {
+impl Satisfier<bitcoin::PublicKey> for psbt::Input {
     fn lookup_pk(&self, pk: &bitcoin::PublicKey) -> Option<BitcoinSig> {
         if let Some(rawsig) = self.partial_sigs.get(pk) {
             let (flag, sig) = rawsig.split_last().unwrap();


### PR DESCRIPTION
Ther are two commits in total
- Add PubkeyTrait:
- Changed Semantic Policy to only accept Pkh for the below reasons. 

This allows to following invariant.
`Lift(Concrete) == Concrete -> Miniscript -> Script -> Miniscript -> Semantic`
Lifting concrete policy is equivalent to the following:
Compiling Concrete to Miniscript followed by
Encoding the miniscript to Script
Decoding it back to Miniscript
And finally lifting it back to Semantic