### PR TITLE
Add cargo fmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 matrix:
   include:
     - rust: stable
-      env: DO_FUZZ=true
+      env: DO_FUZZ=true DO_LINT=true
     - rust: beta
     - rust: nightly
     - rust: 1.22.0

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -8,6 +8,15 @@ then
     alias cargo="cargo +$TOOLCHAIN"
 fi
 
+# Lint if told to
+if [ "$DO_LINT" = true ]
+then
+    (
+        rustup component add rustfmt
+        cargo fmt --all -- --check
+    )
+fi
+
 # Test without any features first
 cargo test --verbose
 

--- a/src/descriptor/create_descriptor.rs
+++ b/src/descriptor/create_descriptor.rs
@@ -4,14 +4,14 @@
 
 use bitcoin::{self, Script};
 
+use bitcoin::blockdata::opcodes;
+use bitcoin::blockdata::script::Instruction;
+use descriptor::satisfied_contraints::Error as IntError;
+use descriptor::satisfied_contraints::StackElement;
 use descriptor::Descriptor;
 use miniscript::Miniscript;
-use descriptor::satisfied_contraints::StackElement;
 use Error;
 use ToPublicKey;
-use bitcoin::blockdata::script::Instruction;
-use bitcoin::blockdata::opcodes;
-use descriptor::satisfied_contraints::Error as IntError;
 
 /// Helper function for creating StackElement from Push instructions. Special case required for
 /// handling OP_PUSHNUM_1.
@@ -23,7 +23,7 @@ use descriptor::satisfied_contraints::Error as IntError;
 ///
 /// NOTE: Miniscript pushes should only be either boolean, 1 or 0, signatures, and hash preimages.
 /// As per the current implementation, PUSH_NUM2 results in an error
-fn instr_to_stackelem<'txin>(ins: &Instruction<'txin>) -> Result< StackElement<'txin>, Error> {
+fn instr_to_stackelem<'txin>(ins: &Instruction<'txin>) -> Result<StackElement<'txin>, Error> {
     match *ins {
         //Also covers the dissatisfied case as PushBytes0
         Instruction::PushBytes(v) => Ok(StackElement::from(v)),
@@ -35,9 +35,11 @@ fn instr_to_stackelem<'txin>(ins: &Instruction<'txin>) -> Result< StackElement<'
 /// Helper function which splits the scriptsig into 2 parts returns the corresponding elements.
 /// Usually used for scripts which have top element as Pk (p2pkh) or redeem script(p2sh).
 /// Converts the other script elements into Vec<StackElement>
-fn parse_scriptsig_top(script_sig: &bitcoin::Script) -> Result<(Vec<u8>, Vec<StackElement>), Error>
-{
-    let stack: Result< Vec<StackElement>, Error> = script_sig.iter(true)
+fn parse_scriptsig_top(
+    script_sig: &bitcoin::Script,
+) -> Result<(Vec<u8>, Vec<StackElement>), Error> {
+    let stack: Result<Vec<StackElement>, Error> = script_sig
+        .iter(true)
         .map(|instr| instr_to_stackelem(&instr))
         .collect();
     let mut stack = stack?;
@@ -53,17 +55,17 @@ fn parse_scriptsig_top(script_sig: &bitcoin::Script) -> Result<(Vec<u8>, Vec<Sta
 fn verify_p2pk<'txin>(
     script_pubkey: &bitcoin::Script,
     script_sig: &'txin bitcoin::Script,
-    witness: & [Vec<u8>],
-) -> Result<(Descriptor<bitcoin::PublicKey>, Vec<StackElement<'txin>>), Error>
-{
+    witness: &[Vec<u8>],
+) -> Result<(Descriptor<bitcoin::PublicKey>, Vec<StackElement<'txin>>), Error> {
     let script_pubkey_len = script_pubkey.len();
     let pk_bytes = &script_pubkey.to_bytes();
-    let pk = bitcoin::PublicKey::from_slice(&pk_bytes[1..script_pubkey_len-1]).unwrap();
+    let pk = bitcoin::PublicKey::from_slice(&pk_bytes[1..script_pubkey_len - 1]).unwrap();
 
-    let stack: Result< Vec<StackElement>, Error> = script_sig.iter(true)
+    let stack: Result<Vec<StackElement>, Error> = script_sig
+        .iter(true)
         .map(|instr| instr_to_stackelem(&instr))
         .collect();
-    if !witness.is_empty(){
+    if !witness.is_empty() {
         Err(Error::NonEmptyWitness)
     } else {
         Ok((Descriptor::Pk(pk), stack?))
@@ -76,28 +78,26 @@ fn verify_p2wpkh<'txin>(
     script_pubkey: &bitcoin::Script,
     script_sig: &bitcoin::Script,
     witness: &'txin [Vec<u8>],
-) -> Result<(bitcoin::PublicKey, Vec<StackElement<'txin>>), Error>
-{
+) -> Result<(bitcoin::PublicKey, Vec<StackElement<'txin>>), Error> {
     //script_sig must be empty
-    if !script_sig.is_empty(){
-        return Err(Error::NonEmptyScriptSig)
+    if !script_sig.is_empty() {
+        return Err(Error::NonEmptyScriptSig);
     }
     if let Some((pk_bytes, witness)) = witness.split_last() {
         if let Ok(pk) = bitcoin::PublicKey::from_slice(pk_bytes) {
-            let addr = bitcoin::Address::p2wpkh(
-                &pk.to_public_key(),
-                bitcoin::Network::Bitcoin,
-            );
+            let addr = bitcoin::Address::p2wpkh(&pk.to_public_key(), bitcoin::Network::Bitcoin);
             if addr.script_pubkey() != *script_pubkey {
-                return Err(Error::InterpreterError(IntError::PkEvaluationError(pk)))
+                return Err(Error::InterpreterError(IntError::PkEvaluationError(pk)));
             }
-            let stack: Vec<StackElement> = witness.iter()
-                .map(|elem| StackElement::from(elem)).collect();
+            let stack: Vec<StackElement> = witness
+                .iter()
+                .map(|elem| StackElement::from(elem))
+                .collect();
             Ok((pk, stack))
-        }else {
+        } else {
             Err(Error::InterpreterError(IntError::PubkeyParseError))
         }
-    } else{
+    } else {
         Err(Error::InterpreterError(IntError::UnexpectedStackEnd))
     }
 }
@@ -110,49 +110,45 @@ fn verify_wsh<'txin>(
     script_pubkey: &bitcoin::Script,
     script_sig: &bitcoin::Script,
     witness: &'txin [Vec<u8>],
-) -> Result<(Miniscript<bitcoin::PublicKey>, Vec<StackElement<'txin>>), Error>
-{
-    if !script_sig.is_empty(){
-        return Err(Error::NonEmptyScriptSig)
+) -> Result<(Miniscript<bitcoin::PublicKey>, Vec<StackElement<'txin>>), Error> {
+    if !script_sig.is_empty() {
+        return Err(Error::NonEmptyScriptSig);
     }
     if let Some((witness_script, witness)) = witness.split_last() {
         let witness_script = Script::from(witness_script.clone());
         if witness_script.to_v0_p2wsh() != *script_pubkey {
-            return Err(Error::IncorrectScriptHash)
+            return Err(Error::IncorrectScriptHash);
         }
         let ms = Miniscript::parse(&witness_script)?;
         //only iter till len -1 to not include the witness script
-        let stack: Vec<StackElement> = witness.iter()
-            .map(|elem| StackElement::from(elem)).collect();
+        let stack: Vec<StackElement> = witness
+            .iter()
+            .map(|elem| StackElement::from(elem))
+            .collect();
         Ok((ms, stack))
-    } else{
+    } else {
         Err(Error::InterpreterError(IntError::UnexpectedStackEnd))
     }
 }
-
 
 /// Creates a pkh descriptor based on scriptsig and script_pubkey. Validates the hash checks for
 /// p2pkh against top element(pk) and pushes all remaining witness elements into witness<StackElement>
 fn verify_p2pkh<'txin>(
     script_pubkey: &bitcoin::Script,
     script_sig: &'txin bitcoin::Script,
-    witness: & [Vec<u8>],
-) -> Result<(Descriptor<bitcoin::PublicKey>, Vec<StackElement<'txin>>), Error>
-{
+    witness: &[Vec<u8>],
+) -> Result<(Descriptor<bitcoin::PublicKey>, Vec<StackElement<'txin>>), Error> {
     let (pk_bytes, stack) = parse_scriptsig_top(script_sig)?;
     if let Ok(pk) = bitcoin::PublicKey::from_slice(&pk_bytes) {
-        let addr = bitcoin::Address::p2pkh(
-            &pk.to_public_key(),
-            bitcoin::Network::Bitcoin,
-        );
-        if !witness.is_empty(){
-            return Err(Error::NonEmptyWitness)
+        let addr = bitcoin::Address::p2pkh(&pk.to_public_key(), bitcoin::Network::Bitcoin);
+        if !witness.is_empty() {
+            return Err(Error::NonEmptyWitness);
         }
         if *script_pubkey != addr.script_pubkey() {
-            return Err(Error::IncorrectPubkeyHash)
+            return Err(Error::IncorrectPubkeyHash);
         }
         Ok((Descriptor::Pkh(pk), stack))
-    } else{
+    } else {
         Err(Error::InterpreterError(IntError::PubkeyParseError))
     }
 }
@@ -163,12 +159,11 @@ fn verify_p2pkh<'txin>(
 fn verify_p2sh<'txin>(
     script_pubkey: &bitcoin::Script,
     script_sig: &'txin bitcoin::Script,
-) -> Result<(Script, Vec<StackElement<'txin>>), Error>
-{
+) -> Result<(Script, Vec<StackElement<'txin>>), Error> {
     let (redeem_script, stack) = parse_scriptsig_top(script_sig)?;
     let redeem_script = Script::from(redeem_script);
     if redeem_script.to_p2sh() != *script_pubkey {
-        return Err(Error::IncorrectScriptHash)
+        return Err(Error::IncorrectScriptHash);
     }
     Ok((redeem_script, stack))
 }
@@ -195,51 +190,44 @@ pub fn witness_stack<'txin>(
     script_pubkey: &bitcoin::Script,
     script_sig: &'txin bitcoin::Script,
     witness: &'txin [Vec<u8>],
-) -> Result<(Descriptor<bitcoin::PublicKey>, Vec<StackElement<'txin>>), Error>
-{
-    if script_pubkey.is_p2pk(){
+) -> Result<(Descriptor<bitcoin::PublicKey>, Vec<StackElement<'txin>>), Error> {
+    if script_pubkey.is_p2pk() {
         verify_p2pk(script_pubkey, script_sig, witness)
-    }else if script_pubkey.is_p2pkh(){
+    } else if script_pubkey.is_p2pkh() {
         verify_p2pkh(script_pubkey, script_sig, witness)
-    }
-    else if script_pubkey.is_v0_p2wpkh(){
+    } else if script_pubkey.is_v0_p2wpkh() {
         let (pk, stack) = verify_p2wpkh(script_pubkey, script_sig, witness)?;
         Ok((Descriptor::Wpkh(pk), stack))
-    }
-    else if script_pubkey.is_v0_p2wsh(){
+    } else if script_pubkey.is_v0_p2wsh() {
         let (ms, stack) = verify_wsh(script_pubkey, script_sig, witness)?;
         Ok((Descriptor::Wsh(ms), stack))
-    }
-    else if script_pubkey.is_p2sh(){
+    } else if script_pubkey.is_p2sh() {
         let (redeem_script, stack) = verify_p2sh(script_pubkey, script_sig)?;
-        if redeem_script.is_v0_p2wpkh()
-        {
+        if redeem_script.is_v0_p2wpkh() {
             //Therefore while calling verify_wpkh, an argument of Script::new() is passed instead
             //of script_sig. The redeem_script becomes the script_pubkey
             let (pk, stack) = verify_p2wpkh(&redeem_script, &Script::new(), witness)?;
             Ok((Descriptor::ShWpkh(pk), stack))
-        }else if redeem_script.is_v0_p2wsh() {
+        } else if redeem_script.is_v0_p2wsh() {
             //Therefore while calling verify_wpkh, an argument of Script::new() is passed instead
             //of script_sig. The redeem_script becomes the script_pubkey
             let (ms, stack) = verify_wsh(&redeem_script, &Script::new(), witness)?;
             Ok((Descriptor::ShWsh(ms), stack))
-        }
-        else{
-            if !witness.is_empty(){
-                return Err(Error::NonEmptyWitness)
+        } else {
+            if !witness.is_empty() {
+                return Err(Error::NonEmptyWitness);
             }
             let ms = Miniscript::parse(&redeem_script)?;
             Ok((Descriptor::Sh(ms), stack))
         }
-    }
-    else{
+    } else {
         //bare
-        let stack : Result <Vec<StackElement>, Error> = script_sig
+        let stack: Result<Vec<StackElement>, Error> = script_sig
             .iter(true)
             .map(|instr| instr_to_stackelem(&instr))
             .collect();
-        if !witness.is_empty(){
-            return Err(Error::NonEmptyWitness)
+        if !witness.is_empty() {
+            return Err(Error::NonEmptyWitness);
         }
         let ms = Miniscript::parse(script_pubkey)?;
         Ok((Descriptor::Bare(ms), stack?))
@@ -248,37 +236,39 @@ pub fn witness_stack<'txin>(
 
 #[cfg(test)]
 mod tests {
-    use ::{Descriptor, Miniscript};
-    use descriptor::create_descriptor::witness_stack;
-    use bitcoin::blockdata::script;
     use bitcoin;
-    use secp256k1::{self, Secp256k1, VerifyOnly};
-    use descriptor::satisfied_contraints::StackElement;
     use bitcoin::blockdata::opcodes;
-    use ToPublicKey;
+    use bitcoin::blockdata::script;
+    use descriptor::create_descriptor::witness_stack;
+    use descriptor::satisfied_contraints::StackElement;
+    use secp256k1::{self, Secp256k1, VerifyOnly};
     use std::str::FromStr;
+    use ToPublicKey;
+    use {Descriptor, Miniscript};
 
-    fn setup_keys_sigs(n: usize)
-                       -> ( Vec<bitcoin::PublicKey>, Vec<Vec<u8> >, secp256k1::Message, Secp256k1<VerifyOnly>) {
+    fn setup_keys_sigs(
+        n: usize,
+    ) -> (
+        Vec<bitcoin::PublicKey>,
+        Vec<Vec<u8>>,
+        secp256k1::Message,
+        Secp256k1<VerifyOnly>,
+    ) {
         let secp_sign = secp256k1::Secp256k1::signing_only();
         let secp_verify = secp256k1::Secp256k1::verification_only();
-        let msg = secp256k1::Message::from_slice(
-            &b"Yoda: btc, I trust. HODL I must!"[..]
-        ).expect("32 bytes");
+        let msg = secp256k1::Message::from_slice(&b"Yoda: btc, I trust. HODL I must!"[..])
+            .expect("32 bytes");
         let mut pks = vec![];
         let mut sigs = vec![];
         let mut sk = [0; 32];
-        for i in 1..n+1 {
+        for i in 1..n + 1 {
             sk[0] = i as u8;
             sk[1] = (i >> 8) as u8;
             sk[2] = (i >> 16) as u8;
 
             let sk = secp256k1::SecretKey::from_slice(&sk[..]).expect("secret key");
             let pk = bitcoin::PublicKey {
-                key: secp256k1::PublicKey::from_secret_key(
-                    &secp_sign,
-                    &sk,
-                ),
+                key: secp256k1::PublicKey::from_secret_key(&secp_sign, &sk),
                 compressed: true,
             };
             let sig = secp_sign.sign(&msg, &sk);
@@ -291,165 +281,123 @@ mod tests {
     }
 
     #[test]
-    fn create_witness_stack(){
-        let (pks,sigs, _, _) = setup_keys_sigs(10);
+    fn create_witness_stack() {
+        let (pks, sigs, _, _) = setup_keys_sigs(10);
 
         //test pkh
-        let script_pubkey =  bitcoin::Address::p2pkh(
-            &pks[0],
-            bitcoin::Network::Bitcoin,
-        ).script_pubkey();
+        let script_pubkey =
+            bitcoin::Address::p2pkh(&pks[0], bitcoin::Network::Bitcoin).script_pubkey();
         let script_sig = script::Builder::new()
             .push_slice(&sigs[0])
             .push_key(&pks[0])
             .into_script();
         let witness = vec![] as Vec<Vec<u8>>;
 
-        let (des, stack) = witness_stack(
-            &script_pubkey,
-            &script_sig,
-            &witness,
-        ).expect("Descriptor/Witness stack creation to succeed");
-        assert_eq!(des_str!("pkh({})",pks[0]), des);
-        assert_eq!(stack,
-                   vec![StackElement::Push(&sigs[0])]);
+        let (des, stack) = witness_stack(&script_pubkey, &script_sig, &witness)
+            .expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(des_str!("pkh({})", pks[0]), des);
+        assert_eq!(stack, vec![StackElement::Push(&sigs[0])]);
 
         //test pk
         let script_pubkey = script::Builder::new()
             .push_key(&pks[0].to_public_key())
             .push_opcode(opcodes::all::OP_CHECKSIG)
             .into_script();
-        let script_sig = script::Builder::new()
-            .push_slice(&sigs[0])
-            .into_script();
+        let script_sig = script::Builder::new().push_slice(&sigs[0]).into_script();
         let witness = vec![] as Vec<Vec<u8>>;
 
-        let (des, stack) = witness_stack(
-            &script_pubkey,
-            &script_sig,
-            &witness,
-        ).expect("Descriptor/Witness stack creation to succeed");
-        assert_eq!(des_str!("pk({})",pks[0]), des);
-        assert_eq!(stack,
-                   vec![StackElement::Push(&sigs[0])]);
+        let (des, stack) = witness_stack(&script_pubkey, &script_sig, &witness)
+            .expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(des_str!("pk({})", pks[0]), des);
+        assert_eq!(stack, vec![StackElement::Push(&sigs[0])]);
 
         //test wpkh
-        let script_pubkey =  bitcoin::Address::p2wpkh(
-            &pks[1],
-            bitcoin::Network::Bitcoin,
-        ).script_pubkey();
+        let script_pubkey =
+            bitcoin::Address::p2wpkh(&pks[1], bitcoin::Network::Bitcoin).script_pubkey();
         let script_sig = script::Builder::new().into_script();
         let witness = vec![sigs[1].clone(), pks[1].clone().to_bytes()];
-        let (des, stack) = witness_stack(
-            &script_pubkey,
-            &script_sig,
-            &witness,
-        ).expect("Descriptor/Witness stack creation to succeed");
-        assert_eq!(des_str!("wpkh({})",pks[1]), des);
+        let (des, stack) = witness_stack(&script_pubkey, &script_sig, &witness)
+            .expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(des_str!("wpkh({})", pks[1]), des);
         assert_eq!(stack, vec![StackElement::Push(&sigs[1])]);
 
         //test Wsh: and(pkv, pk). Note this does not check miniscript.
-        let ms = ms_str!("and_v(vc:pk({}),c:pk({}))",
-                     pks[0], pks[1]);
-        let script_pubkey =  bitcoin::Address::p2wsh(
-            &ms.encode(),
-            bitcoin::Network::Bitcoin,
-        ).script_pubkey();
+        let ms = ms_str!("and_v(vc:pk({}),c:pk({}))", pks[0], pks[1]);
+        let script_pubkey =
+            bitcoin::Address::p2wsh(&ms.encode(), bitcoin::Network::Bitcoin).script_pubkey();
         let script_sig = script::Builder::new().into_script();
         let witness = vec![sigs[1].clone(), sigs[0].clone(), ms.encode().to_bytes()];
-        let (des, stack) = witness_stack(
-            &script_pubkey,
-            &script_sig,
-            &witness,
-        ).expect("Descriptor/Witness stack creation to succeed");
+        let (des, stack) = witness_stack(&script_pubkey, &script_sig, &witness)
+            .expect("Descriptor/Witness stack creation to succeed");
         assert_eq!(Descriptor::Wsh(ms.clone()), des);
-        assert_eq!(stack,
-                   vec![StackElement::Push(&sigs[1]),
-                        StackElement::Push(&sigs[0])]);
+        assert_eq!(
+            stack,
+            vec![StackElement::Push(&sigs[1]), StackElement::Push(&sigs[0])]
+        );
 
         //test Bare: and(pkv, pk). Note this does not check miniscript.
-        let ms = ms_str!("or_b(c:pk({}),sc:pk({}))",
-                     pks[0], pks[1]);
-        let script_pubkey =  ms.encode();
+        let ms = ms_str!("or_b(c:pk({}),sc:pk({}))", pks[0], pks[1]);
+        let script_pubkey = ms.encode();
         let script_sig = script::Builder::new()
             .push_int(0)
             .push_slice(&sigs[0])
             .into_script();
         let witness = vec![] as Vec<Vec<u8>>;
-        let (des, stack) = witness_stack(
-            &script_pubkey,
-            &script_sig,
-            &witness,
-        ).expect("Descriptor/Witness stack creation to succeed");
+        let (des, stack) = witness_stack(&script_pubkey, &script_sig, &witness)
+            .expect("Descriptor/Witness stack creation to succeed");
         assert_eq!(Descriptor::Bare(ms.clone()), des);
-        assert_eq!(stack,
-                   vec![StackElement::Dissatisfied,
-                        StackElement::Push(&sigs[0])]);
+        assert_eq!(
+            stack,
+            vec![StackElement::Dissatisfied, StackElement::Push(&sigs[0])]
+        );
 
         //test Sh: and(pkv, pk). Note this does not check miniscript.
-        let ms = ms_str!("c:or_i(pk({}),pk({}))",
-                     pks[0], pks[1]);
-        let script_pubkey =  bitcoin::Address::p2sh(
-            &ms.encode(),
-            bitcoin::Network::Bitcoin,
-        ).script_pubkey();
+        let ms = ms_str!("c:or_i(pk({}),pk({}))", pks[0], pks[1]);
+        let script_pubkey =
+            bitcoin::Address::p2sh(&ms.encode(), bitcoin::Network::Bitcoin).script_pubkey();
         let script_sig = script::Builder::new()
             .push_slice(&sigs[0])
             .push_int(1)
             .push_slice(&ms.encode().to_bytes())
             .into_script();
         let witness = vec![] as Vec<Vec<u8>>;
-        let (des, stack) = witness_stack(
-            &script_pubkey,
-            &script_sig,
-            &witness,
-        ).expect("Descriptor/Witness stack creation to succeed");
+        let (des, stack) = witness_stack(&script_pubkey, &script_sig, &witness)
+            .expect("Descriptor/Witness stack creation to succeed");
         assert_eq!(Descriptor::Sh(ms.clone()), des);
-        assert_eq!(stack,
-                   vec![StackElement::Push(&sigs[0]),
-                        StackElement::Satisfied]);
+        assert_eq!(
+            stack,
+            vec![StackElement::Push(&sigs[0]), StackElement::Satisfied]
+        );
 
         //test Shwsh: and(pkv, pk). Note this does not check miniscript.
         //This test passes incorrect witness argument.
-        let ms = ms_str!("and_v(vc:pk({}),c:pk({}))",
-                     pks[0], pks[1]);
-        let script_pubkey =  bitcoin::Address::p2shwsh(
-            &ms.encode(),
-            bitcoin::Network::Bitcoin,
-        ).script_pubkey();
+        let ms = ms_str!("and_v(vc:pk({}),c:pk({}))", pks[0], pks[1]);
+        let script_pubkey =
+            bitcoin::Address::p2shwsh(&ms.encode(), bitcoin::Network::Bitcoin).script_pubkey();
         let script_sig = script::Builder::new()
             .push_slice(&ms.encode().to_v0_p2wsh().to_bytes())
             .into_script();
         let witness = vec![sigs[1].clone(), sigs[3].clone(), ms.encode().to_bytes()];
-        let (des, stack) = witness_stack(
-            &script_pubkey,
-            &script_sig,
-            &witness,
-        ).expect("Descriptor/Witness stack creation to succeed");
+        let (des, stack) = witness_stack(&script_pubkey, &script_sig, &witness)
+            .expect("Descriptor/Witness stack creation to succeed");
         assert_eq!(Descriptor::ShWsh(ms.clone()), des);
-        assert_eq!(stack,
-                   vec![StackElement::Push(&sigs[1]),
-                        StackElement::Push(&sigs[3])]);
+        assert_eq!(
+            stack,
+            vec![StackElement::Push(&sigs[1]), StackElement::Push(&sigs[3])]
+        );
 
         //test shwpkh
-        let script_pubkey =  bitcoin::Address::p2shwpkh(
-            &pks[2],
-            bitcoin::Network::Bitcoin,
-        ).script_pubkey();
-        let redeem_script =  bitcoin::Address::p2wpkh(
-            &pks[2],
-            bitcoin::Network::Bitcoin,
-        ).script_pubkey();
+        let script_pubkey =
+            bitcoin::Address::p2shwpkh(&pks[2], bitcoin::Network::Bitcoin).script_pubkey();
+        let redeem_script =
+            bitcoin::Address::p2wpkh(&pks[2], bitcoin::Network::Bitcoin).script_pubkey();
         let script_sig = script::Builder::new()
             .push_slice(&redeem_script.to_bytes())
             .into_script();
         let witness = vec![sigs[2].clone(), pks[2].clone().to_bytes()];
-        let (des, stack) = witness_stack(
-            &script_pubkey,
-            &script_sig,
-            &witness,
-        ).expect("Descriptor/Witness stack creation to succeed");
-        assert_eq!(des_str!("sh(wpkh({}))",pks[2]), des);
+        let (des, stack) = witness_stack(&script_pubkey, &script_sig, &witness)
+            .expect("Descriptor/Witness stack creation to succeed");
+        assert_eq!(des_str!("sh(wpkh({}))", pks[2]), des);
         assert_eq!(stack, vec![StackElement::Push(&sigs[2])]);
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,7 +2,6 @@
 //!
 //! Macros meant to be used inside the Rust Miniscript library
 
-
 /// Allows tests to create a miniscript directly from string as
 /// `ms_str!("c:or_i(pk({}),pk({}))", pk1, pk2)`
 macro_rules! ms_str {

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -25,16 +25,16 @@ use bitcoin::blockdata::{opcodes, script};
 use bitcoin_hashes::hex::FromHex;
 use bitcoin_hashes::{hash160, ripemd160, sha256, sha256d};
 
-use ::{Error, ToHash160};
 use errstr;
 use expression;
-use script_num_size;
-use MiniscriptKey;
-use ToPublicKey;
 use miniscript::types::{self, Property};
-use Miniscript;
-use Terminal;
+use script_num_size;
 use str::FromStr;
+use Miniscript;
+use MiniscriptKey;
+use Terminal;
+use ToPublicKey;
+use {Error, ToHash160};
 
 impl<Pk: MiniscriptKey> Terminal<Pk> {
     /// Internal helper function for displaying wrapper types; returns
@@ -62,9 +62,10 @@ impl<Pk: MiniscriptKey> Terminal<Pk> {
         mut translatefpk: FPk,
         mut translatefpkh: FPkh,
     ) -> Result<Terminal<Q>, Error>
-        where FPk: FnMut(&Pk) -> Result<Q, Error>,
-              FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, Error>,
-              Q: MiniscriptKey,
+    where
+        FPk: FnMut(&Pk) -> Result<Q, Error>,
+        FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, Error>,
+        Q: MiniscriptKey,
     {
         Ok(match *self {
             Terminal::Pk(ref p) => Terminal::Pk(translatefpk(p)?),
@@ -77,55 +78,55 @@ impl<Pk: MiniscriptKey> Terminal<Pk> {
             Terminal::Hash160(x) => Terminal::Hash160(x),
             Terminal::True => Terminal::True,
             Terminal::False => Terminal::False,
-            Terminal::Alt(ref sub) => Terminal::Alt(
-                Box::new(sub.translate_pk(translatefpk, translatefpkh)?),
-            ),
-            Terminal::Swap(ref sub) => Terminal::Swap(
-                Box::new(sub.translate_pk(translatefpk, translatefpkh)?),
-            ),
-            Terminal::Check(ref sub) => Terminal::Check(
-                Box::new(sub.translate_pk(translatefpk, translatefpkh)?),
-            ),
-            Terminal::DupIf(ref sub) => Terminal::DupIf(
-                Box::new(sub.translate_pk(translatefpk, translatefpkh)?),
-            ),
-            Terminal::Verify(ref sub) => Terminal::Verify(
-                Box::new(sub.translate_pk(translatefpk, translatefpkh)?),
-            ),
-            Terminal::NonZero(ref sub) => Terminal::NonZero(
-                Box::new(sub.translate_pk(translatefpk, translatefpkh)?),
-            ),
-            Terminal::ZeroNotEqual(ref sub) => Terminal::ZeroNotEqual(
-                Box::new(sub.translate_pk(translatefpk, translatefpkh)?),
-            ),
+            Terminal::Alt(ref sub) => {
+                Terminal::Alt(Box::new(sub.translate_pk(translatefpk, translatefpkh)?))
+            }
+            Terminal::Swap(ref sub) => {
+                Terminal::Swap(Box::new(sub.translate_pk(translatefpk, translatefpkh)?))
+            }
+            Terminal::Check(ref sub) => {
+                Terminal::Check(Box::new(sub.translate_pk(translatefpk, translatefpkh)?))
+            }
+            Terminal::DupIf(ref sub) => {
+                Terminal::DupIf(Box::new(sub.translate_pk(translatefpk, translatefpkh)?))
+            }
+            Terminal::Verify(ref sub) => {
+                Terminal::Verify(Box::new(sub.translate_pk(translatefpk, translatefpkh)?))
+            }
+            Terminal::NonZero(ref sub) => {
+                Terminal::NonZero(Box::new(sub.translate_pk(translatefpk, translatefpkh)?))
+            }
+            Terminal::ZeroNotEqual(ref sub) => {
+                Terminal::ZeroNotEqual(Box::new(sub.translate_pk(translatefpk, translatefpkh)?))
+            }
             Terminal::AndV(ref left, ref right) => Terminal::AndV(
                 Box::new(left.translate_pk(&mut translatefpk, &mut translatefpkh)?),
-                Box::new(right.translate_pk(translatefpk, translatefpkh )?),
+                Box::new(right.translate_pk(translatefpk, translatefpkh)?),
             ),
             Terminal::AndB(ref left, ref right) => Terminal::AndB(
                 Box::new(left.translate_pk(&mut translatefpk, &mut translatefpkh)?),
-                Box::new(right.translate_pk(translatefpk, translatefpkh )?),
+                Box::new(right.translate_pk(translatefpk, translatefpkh)?),
             ),
             Terminal::AndOr(ref a, ref b, ref c) => Terminal::AndOr(
                 Box::new(a.translate_pk(&mut translatefpk, &mut translatefpkh)?),
                 Box::new(b.translate_pk(&mut translatefpk, &mut translatefpkh)?),
-                Box::new(c.translate_pk(translatefpk, translatefpkh )?),
+                Box::new(c.translate_pk(translatefpk, translatefpkh)?),
             ),
             Terminal::OrB(ref left, ref right) => Terminal::OrB(
                 Box::new(left.translate_pk(&mut translatefpk, &mut translatefpkh)?),
-                Box::new(right.translate_pk(translatefpk, translatefpkh )?),
+                Box::new(right.translate_pk(translatefpk, translatefpkh)?),
             ),
             Terminal::OrD(ref left, ref right) => Terminal::OrD(
                 Box::new(left.translate_pk(&mut translatefpk, &mut translatefpkh)?),
-                Box::new(right.translate_pk(translatefpk, translatefpkh )?),
+                Box::new(right.translate_pk(translatefpk, translatefpkh)?),
             ),
             Terminal::OrC(ref left, ref right) => Terminal::OrC(
                 Box::new(left.translate_pk(&mut translatefpk, &mut translatefpkh)?),
-                Box::new(right.translate_pk(translatefpk, translatefpkh )?),
+                Box::new(right.translate_pk(translatefpk, translatefpkh)?),
             ),
             Terminal::OrI(ref left, ref right) => Terminal::OrI(
                 Box::new(left.translate_pk(&mut translatefpk, &mut translatefpkh)?),
-                Box::new(right.translate_pk(translatefpk, translatefpkh )?),
+                Box::new(right.translate_pk(translatefpk, translatefpkh)?),
             ),
             Terminal::Thresh(k, ref subs) => {
                 let subs: Result<Vec<Miniscript<Q>>, _> = subs
@@ -133,20 +134,16 @@ impl<Pk: MiniscriptKey> Terminal<Pk> {
                     .map(|s| s.translate_pk(&mut translatefpk, &mut translatefpkh))
                     .collect();
                 Terminal::Thresh(k, subs?)
-            },
+            }
             Terminal::ThreshM(k, ref keys) => {
-                let keys: Result<Vec<Q>, _> = keys
-                    .iter()
-                    .map(&mut translatefpk)
-                    .collect();
+                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut translatefpk).collect();
                 Terminal::ThreshM(k, keys?)
             }
         })
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Debug for Terminal<Pk>
-{
+impl<Pk: MiniscriptKey> fmt::Debug for Terminal<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("[")?;
         if let Ok(type_map) = types::Type::type_check(self, |_| None) {
@@ -203,42 +200,36 @@ impl<Pk: MiniscriptKey> fmt::Debug for Terminal<Pk>
                 Terminal::Hash160(h) => write!(f, "hash160({})", h),
                 Terminal::True => f.write_str("1"),
                 Terminal::False => f.write_str("0"),
-                Terminal::AndV(ref l, ref r) =>
-                    write!(f, "and_v({:?},{:?})", l, r),
-                Terminal::AndB(ref l, ref r) =>
-                    write!(f, "and_b({:?},{:?})", l, r),
-                Terminal::AndOr(ref a, ref b, ref c) =>
-                    write!(f, "and_or({:?},{:?},{:?})", a, c, b),
-                Terminal::OrB(ref l, ref r) =>
-                    write!(f, "or_b({:?},{:?})", l, r),
-                Terminal::OrD(ref l, ref r) =>
-                    write!(f, "or_d({:?},{:?})", l, r),
-                Terminal::OrC(ref l, ref r) =>
-                    write!(f, "or_c({:?},{:?})", l, r),
-                Terminal::OrI(ref l, ref r) =>
-                    write!(f, "or_i({:?},{:?})", l, r),
+                Terminal::AndV(ref l, ref r) => write!(f, "and_v({:?},{:?})", l, r),
+                Terminal::AndB(ref l, ref r) => write!(f, "and_b({:?},{:?})", l, r),
+                Terminal::AndOr(ref a, ref b, ref c) => {
+                    write!(f, "and_or({:?},{:?},{:?})", a, c, b)
+                }
+                Terminal::OrB(ref l, ref r) => write!(f, "or_b({:?},{:?})", l, r),
+                Terminal::OrD(ref l, ref r) => write!(f, "or_d({:?},{:?})", l, r),
+                Terminal::OrC(ref l, ref r) => write!(f, "or_c({:?},{:?})", l, r),
+                Terminal::OrI(ref l, ref r) => write!(f, "or_i({:?},{:?})", l, r),
                 Terminal::Thresh(k, ref subs) => {
                     write!(f, "thresh({}", k)?;
                     for s in subs {
                         write!(f, ",{:?}", s)?;
                     }
                     f.write_str(")")
-                },
+                }
                 Terminal::ThreshM(k, ref keys) => {
                     write!(f, "thresh_m({}", k)?;
                     for k in keys {
                         write!(f, "{:?},", k)?;
                     }
                     f.write_str(")")
-                },
+                }
                 _ => unreachable!(),
             }
         }
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Display for Terminal<Pk>
-{
+impl<Pk: MiniscriptKey> fmt::Display for Terminal<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Terminal::Pk(ref pk) => write!(f, "pk({})", pk),
@@ -253,8 +244,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Terminal<Pk>
             Terminal::False => f.write_str("0"),
             Terminal::AndV(ref l, ref r) => write!(f, "and_v({},{})", l, r),
             Terminal::AndB(ref l, ref r) => write!(f, "and_b({},{})", l, r),
-            Terminal::AndOr(ref a, ref b, ref c) =>
-                write!(f, "tern({},{},{})", a, c, b),
+            Terminal::AndOr(ref a, ref b, ref c) => write!(f, "tern({},{},{})", a, c, b),
             Terminal::OrB(ref l, ref r) => write!(f, "or_b({},{})", l, r),
             Terminal::OrD(ref l, ref r) => write!(f, "or_d({},{})", l, r),
             Terminal::OrC(ref l, ref r) => write!(f, "or_c({},{})", l, r),
@@ -265,14 +255,14 @@ impl<Pk: MiniscriptKey> fmt::Display for Terminal<Pk>
                     write!(f, ",{}", s)?;
                 }
                 f.write_str(")")
-            },
+            }
             Terminal::ThreshM(k, ref keys) => {
                 write!(f, "thresh_m({}", k)?;
                 for k in keys {
                     write!(f, ",{}", k)?;
                 }
                 f.write_str(")")
-            },
+            }
             // wrappers
             _ => {
                 if let Some((ch, sub)) = self.wrap_char() {
@@ -284,22 +274,24 @@ impl<Pk: MiniscriptKey> fmt::Display for Terminal<Pk>
                 } else {
                     unreachable!();
                 }
-            },
+            }
         }
     }
 }
 
-impl<Pk> expression::FromTree for Box<Terminal<Pk>> where
+impl<Pk> expression::FromTree for Box<Terminal<Pk>>
+where
     Pk: MiniscriptKey,
     <Pk as str::FromStr>::Err: ToString,
-    <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString
+    <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
 {
     fn from_tree(top: &expression::Tree) -> Result<Box<Terminal<Pk>>, Error> {
         Ok(Box::new(expression::FromTree::from_tree(top)?))
     }
 }
 
-impl<Pk> expression::FromTree for Terminal<Pk> where
+impl<Pk> expression::FromTree for Terminal<Pk>
+where
     Pk: MiniscriptKey,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
@@ -312,52 +304,42 @@ impl<Pk> expression::FromTree for Terminal<Pk> where
             (None, _, _) => {
                 frag_name = "";
                 frag_wrap = "";
-            },
+            }
             (Some(name), None, _) => {
                 frag_name = name;
                 frag_wrap = "";
-            },
+            }
             (Some(wrap), Some(name), None) => {
                 frag_name = name;
                 frag_wrap = wrap;
-            },
+            }
             (Some(_), Some(_), Some(_)) => {
                 return Err(Error::MultiColon(top.name.to_owned()));
-            },
+            }
         }
         let mut unwrapped = match (frag_name, top.args.len()) {
-            ("pk", 1) => expression::terminal(
-                &top.args[0],
-                |x| Pk::from_str(x).map(Terminal::Pk)
-            ),
-            ("pk_h", 1) => expression::terminal(
-                &top.args[0],
-                |x| Pk::Hash::from_str(x).map(Terminal::PkH)
-            ),
-            ("after", 1) => expression::terminal(
-                &top.args[0],
-                |x| expression::parse_num(x).map(Terminal::After)
-            ),
-            ("older", 1) => expression::terminal(
-                &top.args[0],
-                |x| expression::parse_num(x).map(Terminal::Older)
-            ),
-            ("sha256", 1) => expression::terminal(
-                &top.args[0],
-                |x| sha256::Hash::from_hex(x).map(Terminal::Sha256)
-            ),
-            ("hash256", 1) => expression::terminal(
-                &top.args[0],
-                |x| sha256d::Hash::from_hex(x).map(Terminal::Hash256)
-            ),
-            ("ripemd160", 1) => expression::terminal(
-                &top.args[0],
-                |x| ripemd160::Hash::from_hex(x).map(Terminal::Ripemd160)
-            ),
-            ("hash160", 1) => expression::terminal(
-                &top.args[0],
-                |x| hash160::Hash::from_hex(x).map(Terminal::Hash160)
-            ),
+            ("pk", 1) => expression::terminal(&top.args[0], |x| Pk::from_str(x).map(Terminal::Pk)),
+            ("pk_h", 1) => {
+                expression::terminal(&top.args[0], |x| Pk::Hash::from_str(x).map(Terminal::PkH))
+            }
+            ("after", 1) => expression::terminal(&top.args[0], |x| {
+                expression::parse_num(x).map(Terminal::After)
+            }),
+            ("older", 1) => expression::terminal(&top.args[0], |x| {
+                expression::parse_num(x).map(Terminal::Older)
+            }),
+            ("sha256", 1) => expression::terminal(&top.args[0], |x| {
+                sha256::Hash::from_hex(x).map(Terminal::Sha256)
+            }),
+            ("hash256", 1) => expression::terminal(&top.args[0], |x| {
+                sha256d::Hash::from_hex(x).map(Terminal::Hash256)
+            }),
+            ("ripemd160", 1) => expression::terminal(&top.args[0], |x| {
+                ripemd160::Hash::from_hex(x).map(Terminal::Ripemd160)
+            }),
+            ("hash160", 1) => expression::terminal(&top.args[0], |x| {
+                hash160::Hash::from_hex(x).map(Terminal::Hash160)
+            }),
             ("true", 0) => Ok(Terminal::True),
             ("and_v", 2) => expression::binary(top, Terminal::AndV),
             ("and_b", 2) => expression::binary(top, Terminal::AndB),
@@ -379,24 +361,26 @@ impl<Pk> expression::FromTree for Terminal<Pk> where
                     return Err(errstr("empty thresholds not allowed in descriptors"));
                 }
 
-                let subs: Result<Vec<Miniscript<Pk>>, _> = top.args[1..].iter().map(|sub|
-                    expression::FromTree::from_tree(sub)
-                ).collect();
+                let subs: Result<Vec<Miniscript<Pk>>, _> = top.args[1..]
+                    .iter()
+                    .map(|sub| expression::FromTree::from_tree(sub))
+                    .collect();
 
                 Ok(Terminal::Thresh(k, subs?))
-            },
+            }
             ("thresh_m", n) => {
                 let k = expression::terminal(&top.args[0], expression::parse_num)? as usize;
                 if n == 0 || k > n - 1 {
                     return Err(errstr("higher threshold than there were keys in multi"));
                 }
 
-                let pks: Result<Vec<Pk>, _> = top.args[1..].iter().map(|sub|
-                    expression::terminal(sub, Pk::from_str)
-                ).collect();
+                let pks: Result<Vec<Pk>, _> = top.args[1..]
+                    .iter()
+                    .map(|sub| expression::terminal(sub, Pk::from_str))
+                    .collect();
 
                 pks.map(|pks| Terminal::ThreshM(k, pks))
-            },
+            }
             _ => Err(Error::Unexpected(format!(
                 "{}({} args) while parsing Miniscript",
                 top.name,
@@ -411,7 +395,9 @@ impl<Pk> expression::FromTree for Terminal<Pk> where
                 'd' => unwrapped = Terminal::DupIf(Box::new(Miniscript::from_ast(unwrapped)?)),
                 'v' => unwrapped = Terminal::Verify(Box::new(Miniscript::from_ast(unwrapped)?)),
                 'j' => unwrapped = Terminal::NonZero(Box::new(Miniscript::from_ast(unwrapped)?)),
-                'u' => unwrapped = Terminal::ZeroNotEqual(Box::new(Miniscript::from_ast(unwrapped)?)),
+                'u' => {
+                    unwrapped = Terminal::ZeroNotEqual(Box::new(Miniscript::from_ast(unwrapped)?))
+                }
                 x => return Err(Error::UnknownWrapper(x)),
             }
         }
@@ -428,8 +414,10 @@ trait BadTrait {
     fn push_verify(self) -> Self;
 }
 
-impl<Pk> PushAstElem<Pk> for script::Builder where
-    Pk: MiniscriptKey + ToPublicKey, Pk::Hash: ToHash160,
+impl<Pk> PushAstElem<Pk> for script::Builder
+where
+    Pk: MiniscriptKey + ToPublicKey,
+    Pk::Hash: ToHash160,
 {
     fn push_astelem(self, ast: &Miniscript<Pk>) -> Self {
         ast.node.encode(self)
@@ -463,7 +451,8 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
     /// function, from Script to an AST element, is implemented in the
     /// `parse` module.
     pub fn encode(&self, mut builder: script::Builder) -> script::Builder
-    where Pk::Hash: ToHash160
+    where
+        Pk::Hash: ToHash160,
     {
         match *self {
             Terminal::Pk(ref pk) => builder.push_key(&pk.to_public_key()),
@@ -472,12 +461,8 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
                 .push_opcode(opcodes::all::OP_HASH160)
                 .push_slice(&hash.to_hash160()[..])
                 .push_opcode(opcodes::all::OP_EQUALVERIFY),
-            Terminal::After(t) => builder
-                .push_int(t as i64)
-                .push_opcode(opcodes::OP_CSV),
-            Terminal::Older(t) => builder
-                .push_int(t as i64)
-                .push_opcode(opcodes::OP_CLTV),
+            Terminal::After(t) => builder.push_int(t as i64).push_opcode(opcodes::OP_CSV),
+            Terminal::Older(t) => builder.push_int(t as i64).push_opcode(opcodes::OP_CLTV),
             Terminal::Sha256(h) => builder
                 .push_opcode(opcodes::all::OP_SIZE)
                 .push_int(32)
@@ -512,9 +497,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
                 .push_opcode(opcodes::all::OP_TOALTSTACK)
                 .push_astelem(sub)
                 .push_opcode(opcodes::all::OP_FROMALTSTACK),
-            Terminal::Swap(ref sub) => builder
-                .push_opcode(opcodes::all::OP_SWAP)
-                .push_astelem(sub),
+            Terminal::Swap(ref sub) => builder.push_opcode(opcodes::all::OP_SWAP).push_astelem(sub),
             Terminal::Check(ref sub) => builder
                 .push_astelem(sub)
                 .push_opcode(opcodes::all::OP_CHECKSIG),
@@ -523,9 +506,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
                 .push_opcode(opcodes::all::OP_IF)
                 .push_astelem(sub)
                 .push_opcode(opcodes::all::OP_ENDIF),
-            Terminal::Verify(ref sub) => builder
-                .push_astelem(sub)
-                .push_verify(),
+            Terminal::Verify(ref sub) => builder.push_astelem(sub).push_verify(),
             Terminal::NonZero(ref sub) => builder
                 .push_opcode(opcodes::all::OP_SIZE)
                 .push_opcode(opcodes::all::OP_0NOTEQUAL)
@@ -535,9 +516,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
             Terminal::ZeroNotEqual(ref sub) => builder
                 .push_astelem(sub)
                 .push_opcode(opcodes::all::OP_0NOTEQUAL),
-            Terminal::AndV(ref left, ref right) => builder
-                .push_astelem(left)
-                .push_astelem(right),
+            Terminal::AndV(ref left, ref right) => builder.push_astelem(left).push_astelem(right),
             Terminal::AndB(ref left, ref right) => builder
                 .push_astelem(left)
                 .push_astelem(right)
@@ -573,14 +552,12 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
             Terminal::Thresh(k, ref subs) => {
                 builder = builder.push_astelem(&subs[0]);
                 for sub in &subs[1..] {
-                    builder = builder
-                        .push_astelem(sub)
-                        .push_opcode(opcodes::all::OP_ADD);
+                    builder = builder.push_astelem(sub).push_opcode(opcodes::all::OP_ADD);
                 }
                 builder
                     .push_int(k as i64)
                     .push_opcode(opcodes::all::OP_EQUAL)
-            },
+            }
             Terminal::ThreshM(k, ref keys) => {
                 builder = builder.push_int(k as i64);
                 for pk in keys {
@@ -589,7 +566,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
                 builder
                     .push_int(keys.len() as i64)
                     .push_opcode(opcodes::all::OP_CHECKMULTISIG)
-            },
+            }
         }
     }
 
@@ -616,24 +593,25 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
             Terminal::Swap(ref sub) => sub.node.script_size() + 1,
             Terminal::Check(ref sub) => sub.node.script_size() + 1,
             Terminal::DupIf(ref sub) => sub.node.script_size() + 3,
-            Terminal::Verify(ref sub) => sub.node.script_size() +
-                match sub.node {
-                    Terminal::Sha256(..) |
-                    Terminal::Hash256(..) |
-                    Terminal::Ripemd160(..) |
-                    Terminal::Hash160(..) |
-                    Terminal::Check(..) |
-                    Terminal::ThreshM(..) => 0,
-                    _ => 1,
-                },
+            Terminal::Verify(ref sub) => {
+                sub.node.script_size()
+                    + match sub.node {
+                        Terminal::Sha256(..)
+                        | Terminal::Hash256(..)
+                        | Terminal::Ripemd160(..)
+                        | Terminal::Hash160(..)
+                        | Terminal::Check(..)
+                        | Terminal::ThreshM(..) => 0,
+                        _ => 1,
+                    }
+            }
             Terminal::NonZero(ref sub) => sub.node.script_size() + 4,
             Terminal::ZeroNotEqual(ref sub) => sub.node.script_size() + 1,
             Terminal::AndV(ref l, ref r) => l.node.script_size() + r.node.script_size(),
             Terminal::AndB(ref l, ref r) => l.node.script_size() + r.node.script_size() + 1,
-            Terminal::AndOr(ref a, ref b, ref c) => a.node.script_size()
-                + b.node.script_size()
-                + c.node.script_size()
-                + 3,
+            Terminal::AndOr(ref a, ref b, ref c) => {
+                a.node.script_size() + b.node.script_size() + c.node.script_size() + 3
+            }
             Terminal::OrB(ref l, ref r) => l.node.script_size() + r.node.script_size() + 1,
             Terminal::OrD(ref l, ref r) => l.node.script_size() + r.node.script_size() + 3,
             Terminal::OrC(ref l, ref r) => l.node.script_size() + r.node.script_size() + 2,
@@ -646,10 +624,12 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
                     + subs.len() // ADD
                     - 1 // no ADD on first element
             }
-            Terminal::ThreshM(k, ref pks) => script_num_size(k)
-                + 1
-                + script_num_size(pks.len())
-                + pks.iter().map(ToPublicKey::serialized_len).sum::<usize>(),
+            Terminal::ThreshM(k, ref pks) => {
+                script_num_size(k)
+                    + 1
+                    + script_num_size(pks.len())
+                    + pks.iter().map(ToPublicKey::serialized_len).sum::<usize>()
+            }
         }
     }
 
@@ -662,25 +642,22 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
         match *self {
             Terminal::Pk(..) => Some(1),
             Terminal::False => Some(0),
-            Terminal::Alt(ref sub)
-                | Terminal::Swap(ref sub)
-                | Terminal::Check(ref sub)
-                => sub.node.max_dissatisfaction_witness_elements(),
-            Terminal::DupIf(..)
-                | Terminal::NonZero(..) => Some(1),
+            Terminal::Alt(ref sub) | Terminal::Swap(ref sub) | Terminal::Check(ref sub) => {
+                sub.node.max_dissatisfaction_witness_elements()
+            }
+            Terminal::DupIf(..) | Terminal::NonZero(..) => Some(1),
             Terminal::AndB(ref l, ref r) => Some(
                 l.node.max_dissatisfaction_witness_elements()?
-                    + r.node.max_dissatisfaction_witness_elements()?
+                    + r.node.max_dissatisfaction_witness_elements()?,
             ),
             Terminal::AndOr(ref a, _, ref c) => Some(
                 a.node.max_dissatisfaction_witness_elements()?
-                    + c.node.max_dissatisfaction_witness_elements()?
+                    + c.node.max_dissatisfaction_witness_elements()?,
             ),
-            Terminal::OrB(ref l, ref r)
-                | Terminal::OrD(ref l, ref r) => Some(
-                    l.node.max_dissatisfaction_witness_elements()?
-                        + r.node.max_dissatisfaction_witness_elements()?
-                ),
+            Terminal::OrB(ref l, ref r) | Terminal::OrD(ref l, ref r) => Some(
+                l.node.max_dissatisfaction_witness_elements()?
+                    + r.node.max_dissatisfaction_witness_elements()?,
+            ),
             Terminal::OrI(ref l, ref r) => match (
                 l.node.max_dissatisfaction_witness_elements(),
                 r.node.max_dissatisfaction_witness_elements(),
@@ -699,7 +676,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
                     }
                 }
                 Some(sum)
-            },
+            }
             Terminal::ThreshM(k, _) => Some(1 + k),
             _ => None,
         }
@@ -714,25 +691,22 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
         match *self {
             Terminal::Pk(..) => Some(1),
             Terminal::False => Some(0),
-            Terminal::Alt(ref sub)
-                | Terminal::Swap(ref sub)
-                | Terminal::Check(ref sub)
-                => sub.node.max_dissatisfaction_size(one_cost),
-            Terminal::DupIf(..)
-                | Terminal::NonZero(..) => Some(1),
+            Terminal::Alt(ref sub) | Terminal::Swap(ref sub) | Terminal::Check(ref sub) => {
+                sub.node.max_dissatisfaction_size(one_cost)
+            }
+            Terminal::DupIf(..) | Terminal::NonZero(..) => Some(1),
             Terminal::AndB(ref l, ref r) => Some(
                 l.node.max_dissatisfaction_size(one_cost)?
-                    + r.node.max_dissatisfaction_size(one_cost)?
+                    + r.node.max_dissatisfaction_size(one_cost)?,
             ),
             Terminal::AndOr(ref a, _, ref c) => Some(
                 a.node.max_dissatisfaction_size(one_cost)?
-                    + c.node.max_dissatisfaction_size(one_cost)?
+                    + c.node.max_dissatisfaction_size(one_cost)?,
             ),
-            Terminal::OrB(ref l, ref r)
-                | Terminal::OrD(ref l, ref r) => Some(
-                    l.node.max_dissatisfaction_size(one_cost)?
-                        + r.node.max_dissatisfaction_size(one_cost)?
-                ),
+            Terminal::OrB(ref l, ref r) | Terminal::OrD(ref l, ref r) => Some(
+                l.node.max_dissatisfaction_size(one_cost)?
+                    + r.node.max_dissatisfaction_size(one_cost)?,
+            ),
             Terminal::OrI(ref l, ref r) => match (
                 l.node.max_dissatisfaction_witness_elements(),
                 r.node.max_dissatisfaction_witness_elements(),
@@ -751,7 +725,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
                     }
                 }
                 Some(sum)
-            },
+            }
             Terminal::ThreshM(k, _) => Some(1 + k),
             _ => None,
         }
@@ -767,69 +741,63 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
         match *self {
             Terminal::Pk(..) => 1,
             Terminal::PkH(..) => 2,
-            Terminal::After(..)
-                | Terminal::Older(..) => 0,
+            Terminal::After(..) | Terminal::Older(..) => 0,
             Terminal::Sha256(..)
-                | Terminal::Hash256(..)
-                | Terminal::Ripemd160(..)
-                | Terminal::Hash160(..) => 1,
+            | Terminal::Hash256(..)
+            | Terminal::Ripemd160(..)
+            | Terminal::Hash160(..) => 1,
             Terminal::True => 0,
             Terminal::False => 0,
-            Terminal::Alt(ref sub) |
-            Terminal::Swap(ref sub) |
-            Terminal::Check(ref sub) => sub.node.max_satisfaction_witness_elements(),
+            Terminal::Alt(ref sub) | Terminal::Swap(ref sub) | Terminal::Check(ref sub) => {
+                sub.node.max_satisfaction_witness_elements()
+            }
             Terminal::DupIf(ref sub) => 1 + sub.node.max_satisfaction_witness_elements(),
             Terminal::Verify(ref sub)
-                | Terminal::NonZero(ref sub)
-                | Terminal::ZeroNotEqual(ref sub)
-                => sub.node.max_satisfaction_witness_elements(),
-            Terminal::AndV(ref l, ref r)
-                | Terminal::AndB(ref l, ref r)
-                => l.node.max_satisfaction_witness_elements()
-                    + r.node.max_satisfaction_witness_elements(),
+            | Terminal::NonZero(ref sub)
+            | Terminal::ZeroNotEqual(ref sub) => sub.node.max_satisfaction_witness_elements(),
+            Terminal::AndV(ref l, ref r) | Terminal::AndB(ref l, ref r) => {
+                l.node.max_satisfaction_witness_elements()
+                    + r.node.max_satisfaction_witness_elements()
+            }
             Terminal::AndOr(ref a, ref b, ref c) => cmp::max(
-                a.max_satisfaction_witness_elements()
-                    + c.max_satisfaction_witness_elements(),
+                a.max_satisfaction_witness_elements() + c.max_satisfaction_witness_elements(),
                 b.max_satisfaction_witness_elements(),
             ),
             Terminal::OrB(ref l, ref r) => cmp::max(
                 l.node.max_satisfaction_witness_elements()
                     + r.node.max_dissatisfaction_witness_elements().unwrap(),
-                l.node.max_dissatisfaction_witness_elements().unwrap() +
-                    r.node.max_satisfaction_witness_elements(),
+                l.node.max_dissatisfaction_witness_elements().unwrap()
+                    + r.node.max_satisfaction_witness_elements(),
             ),
-            Terminal::OrD(ref l, ref r) |
-            Terminal::OrC(ref l, ref r) => cmp::max(
+            Terminal::OrD(ref l, ref r) | Terminal::OrC(ref l, ref r) => cmp::max(
                 l.node.max_satisfaction_witness_elements(),
-                l.node.max_dissatisfaction_witness_elements().unwrap() +
+                l.node.max_dissatisfaction_witness_elements().unwrap()
+                    + r.node.max_satisfaction_witness_elements(),
+            ),
+            Terminal::OrI(ref l, ref r) => {
+                1 + cmp::max(
+                    l.node.max_satisfaction_witness_elements(),
                     r.node.max_satisfaction_witness_elements(),
-            ),
-            Terminal::OrI(ref l, ref r) => 1 + cmp::max(
-                l.node.max_satisfaction_witness_elements(),
-                r.node.max_satisfaction_witness_elements(),
-            ),
+                )
+            }
             Terminal::Thresh(k, ref subs) => {
                 let mut sub_n = subs
                     .iter()
-                    .map(|sub| (
-                        sub.node.max_satisfaction_witness_elements(),
-                        sub.node.max_dissatisfaction_witness_elements().unwrap(),
-                    ))
+                    .map(|sub| {
+                        (
+                            sub.node.max_satisfaction_witness_elements(),
+                            sub.node.max_dissatisfaction_witness_elements().unwrap(),
+                        )
+                    })
                     .collect::<Vec<(usize, usize)>>();
                 sub_n.sort_by_key(|&(x, y)| x - y);
                 sub_n
                     .iter()
                     .rev()
                     .enumerate()
-                    .map(|(n, &(x, y))|
-                        if n < k {
-                            x
-                        } else {
-                            y
-                        }
-                    )
+                    .map(|(n, &(x, y))| if n < k { x } else { y })
                     .sum::<usize>()
-            },
+            }
             Terminal::ThreshM(k, _) => 1 + k,
         }
     }
@@ -854,31 +822,25 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
         match *self {
             Terminal::Pk(..) => 73,
             Terminal::PkH(..) => 34 + 73,
-            Terminal::After(..)
-                | Terminal::Older(..) => 0,
+            Terminal::After(..) | Terminal::Older(..) => 0,
             Terminal::Sha256(..)
-                | Terminal::Hash256(..)
-                | Terminal::Ripemd160(..)
-                | Terminal::Hash160(..) => 33,
+            | Terminal::Hash256(..)
+            | Terminal::Ripemd160(..)
+            | Terminal::Hash160(..) => 33,
             Terminal::True => 0,
             Terminal::False => 0,
-            Terminal::Alt(ref sub)
-                | Terminal::Swap(ref sub)
-                | Terminal::Check(ref sub)
-                => sub.node.max_satisfaction_size(one_cost),
-            Terminal::DupIf(ref sub)
-                => one_cost + sub.node.max_satisfaction_size(one_cost),
+            Terminal::Alt(ref sub) | Terminal::Swap(ref sub) | Terminal::Check(ref sub) => {
+                sub.node.max_satisfaction_size(one_cost)
+            }
+            Terminal::DupIf(ref sub) => one_cost + sub.node.max_satisfaction_size(one_cost),
             Terminal::Verify(ref sub)
-                | Terminal::NonZero(ref sub)
-                | Terminal::ZeroNotEqual(ref sub)
-                => sub.node.max_satisfaction_size(one_cost),
-            Terminal::AndV(ref l, ref r)
-                | Terminal::AndB(ref l, ref r)
-                => l.node.max_satisfaction_size(one_cost)
-                    + r.node.max_satisfaction_size(one_cost),
+            | Terminal::NonZero(ref sub)
+            | Terminal::ZeroNotEqual(ref sub) => sub.node.max_satisfaction_size(one_cost),
+            Terminal::AndV(ref l, ref r) | Terminal::AndB(ref l, ref r) => {
+                l.node.max_satisfaction_size(one_cost) + r.node.max_satisfaction_size(one_cost)
+            }
             Terminal::AndOr(ref a, ref b, ref c) => cmp::max(
-                a.max_satisfaction_size(one_cost)
-                    + c.max_satisfaction_size(one_cost),
+                a.max_satisfaction_size(one_cost) + c.max_satisfaction_size(one_cost),
                 b.max_satisfaction_size(one_cost),
             ),
             Terminal::OrB(ref l, ref r) => cmp::max(
@@ -887,8 +849,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
                 l.node.max_dissatisfaction_size(one_cost).unwrap()
                     + r.node.max_satisfaction_size(one_cost),
             ),
-            Terminal::OrD(ref l, ref r) |
-            Terminal::OrC(ref l, ref r) => cmp::max(
+            Terminal::OrD(ref l, ref r) | Terminal::OrC(ref l, ref r) => cmp::max(
                 l.node.max_satisfaction_size(one_cost),
                 l.node.max_dissatisfaction_size(one_cost).unwrap()
                     + r.node.max_satisfaction_size(one_cost),
@@ -900,27 +861,22 @@ impl<Pk: MiniscriptKey + ToPublicKey> Terminal<Pk> {
             Terminal::Thresh(k, ref subs) => {
                 let mut sub_n = subs
                     .iter()
-                    .map(|sub| (
-                        sub.node.max_satisfaction_size(one_cost),
-                        sub.node.max_dissatisfaction_size(one_cost).unwrap(),
-                    ))
+                    .map(|sub| {
+                        (
+                            sub.node.max_satisfaction_size(one_cost),
+                            sub.node.max_dissatisfaction_size(one_cost).unwrap(),
+                        )
+                    })
                     .collect::<Vec<(usize, usize)>>();
                 sub_n.sort_by_key(|&(x, y)| x - y);
                 sub_n
                     .iter()
                     .rev()
                     .enumerate()
-                    .map(|(n, &(x, y))|
-                        if n < k {
-                            x
-                        } else {
-                            y
-                        }
-                    )
+                    .map(|(n, &(x, y))| if n < k { x } else { y })
                     .sum::<usize>()
-            },
+            }
             Terminal::ThreshM(k, _) => 1 + 73 * k,
         }
     }
 }
-

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -68,13 +68,13 @@ impl fmt::Display for Token {
                     write!(f, "{:02x}", *ch)?;
                 }
                 Ok(())
-            },
+            }
             Token::Hash32(hash) => {
                 for ch in &hash[..] {
                     write!(f, "{:02x}", *ch)?;
                 }
                 Ok(())
-            },
+            }
             Token::Pubkey(pk) => write!(f, "{}", pk),
             x => write!(f, "{:?}", x),
         }
@@ -121,113 +121,114 @@ pub fn lex(script: &script::Script) -> Result<Vec<Token>, Error> {
             script::Instruction::Error(e) => return Err(Error::Script(e)),
             script::Instruction::Op(opcodes::all::OP_BOOLAND) => {
                 ret.push(Token::BoolAnd);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_BOOLOR) => {
                 ret.push(Token::BoolOr);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_EQUAL) => {
                 ret.push(Token::Equal);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_EQUALVERIFY) => {
                 ret.push(Token::Equal);
                 ret.push(Token::Verify);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_CHECKSIG) => {
                 ret.push(Token::CheckSig);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_CHECKSIGVERIFY) => {
                 ret.push(Token::CheckSig);
                 ret.push(Token::Verify);
             }
             script::Instruction::Op(opcodes::all::OP_CHECKMULTISIG) => {
                 ret.push(Token::CheckMultiSig);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_CHECKMULTISIGVERIFY) => {
                 ret.push(Token::CheckMultiSig);
                 ret.push(Token::Verify);
             }
             script::Instruction::Op(op) if op == opcodes::OP_CSV => {
                 ret.push(Token::CheckSequenceVerify);
-            },
+            }
             script::Instruction::Op(op) if op == opcodes::OP_CLTV => {
                 ret.push(Token::CheckLockTimeVerify);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_FROMALTSTACK) => {
                 ret.push(Token::FromAltStack);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_TOALTSTACK) => {
                 ret.push(Token::ToAltStack);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_DROP) => {
                 ret.push(Token::Drop);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_DUP) => {
                 ret.push(Token::Dup);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_ADD) => {
                 ret.push(Token::Add);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_IF) => {
                 ret.push(Token::If);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_IFDUP) => {
                 ret.push(Token::IfDup);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_NOTIF) => {
                 ret.push(Token::NotIf);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_ELSE) => {
                 ret.push(Token::Else);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_ENDIF) => {
                 ret.push(Token::EndIf);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_0NOTEQUAL) => {
                 ret.push(Token::ZeroNotEqual);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_SIZE) => {
                 ret.push(Token::Size);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_SWAP) => {
                 ret.push(Token::Swap);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_VERIFY) => {
                 match ret.last() {
                     Some(op @ &Token::Equal)
-                        | Some(op @ &Token::CheckSig)
-                        | Some(op @ &Token::CheckMultiSig)
-                        => return Err(Error::NonMinimalVerify(*op)),
+                    | Some(op @ &Token::CheckSig)
+                    | Some(op @ &Token::CheckMultiSig) => return Err(Error::NonMinimalVerify(*op)),
                     _ => {}
                 }
                 ret.push(Token::Verify);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_RIPEMD160) => {
                 ret.push(Token::Ripemd160);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_HASH160) => {
                 ret.push(Token::Hash160);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_SHA256) => {
                 ret.push(Token::Sha256);
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_HASH256) => {
                 ret.push(Token::Hash256);
-            },
+            }
             script::Instruction::PushBytes(bytes) => {
                 match bytes.len() {
                     20 => {
                         let mut x = [0; 20];
                         x.copy_from_slice(bytes);
                         ret.push(Token::Hash20(x))
-                    },
+                    }
                     32 => {
                         let mut x = [0; 32];
                         x.copy_from_slice(bytes);
                         ret.push(Token::Hash32(x))
-                    },
+                    }
                     33 => {
-                        ret.push(Token::Pubkey(PublicKey::from_slice(bytes).map_err(Error::BadPubkey)?));
-                    },
+                        ret.push(Token::Pubkey(
+                            PublicKey::from_slice(bytes).map_err(Error::BadPubkey)?,
+                        ));
+                    }
                     _ => {
                         match script::read_scriptint(bytes) {
                             Ok(v) if v >= 0 => {
@@ -245,55 +246,55 @@ pub fn lex(script: &script::Script) -> Result<Vec<Token>, Error> {
             }
             script::Instruction::Op(opcodes::all::OP_PUSHBYTES_0) => {
                 ret.push(Token::Num(0));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_1) => {
                 ret.push(Token::Num(1));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_2) => {
                 ret.push(Token::Num(2));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_3) => {
                 ret.push(Token::Num(3));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_4) => {
                 ret.push(Token::Num(4));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_5) => {
                 ret.push(Token::Num(5));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_6) => {
                 ret.push(Token::Num(6));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_7) => {
                 ret.push(Token::Num(7));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_8) => {
                 ret.push(Token::Num(8));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_9) => {
                 ret.push(Token::Num(9));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_10) => {
                 ret.push(Token::Num(10));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_11) => {
                 ret.push(Token::Num(11));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_12) => {
                 ret.push(Token::Num(12));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_13) => {
                 ret.push(Token::Num(13));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_14) => {
                 ret.push(Token::Num(14));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_15) => {
                 ret.push(Token::Num(15));
-            },
+            }
             script::Instruction::Op(opcodes::all::OP_PUSHNUM_16) => {
                 ret.push(Token::Num(16));
-            },
+            }
             script::Instruction::Op(op) => return Err(Error::InvalidOpcode(op)),
         };
     }

--- a/src/miniscript/types/correctness.rs
+++ b/src/miniscript/types/correctness.rs
@@ -81,18 +81,18 @@ pub struct Correctness {
 impl Property for Correctness {
     fn sanity_checks(&self) {
         match self.base {
-            Base::B => {},
+            Base::B => {}
             Base::K => {
                 debug_assert!(self.unit);
-            },
+            }
             Base::V => {
                 debug_assert!(!self.unit);
                 debug_assert!(!self.dissatisfiable);
-            },
+            }
             Base::W => {
                 debug_assert!(self.input != Input::OneNonZero);
                 debug_assert!(self.input != Input::AnyNonZero);
-            },
+            }
         }
     }
 
@@ -286,12 +286,11 @@ impl Property for Correctness {
             },
             input: match (left.input, right.input) {
                 (Input::Zero, Input::Zero) => Input::Zero,
-                (Input::Zero, Input::One)
-                    | (Input::One, Input::Zero) => Input::One,
-                (Input::Zero, Input::OneNonZero)
-                    | (Input::OneNonZero, Input::Zero) => Input::OneNonZero,
-                (Input::AnyNonZero, _)
-                    | (Input::Zero, Input::AnyNonZero) => Input::AnyNonZero,
+                (Input::Zero, Input::One) | (Input::One, Input::Zero) => Input::One,
+                (Input::Zero, Input::OneNonZero) | (Input::OneNonZero, Input::Zero) => {
+                    Input::OneNonZero
+                }
+                (Input::AnyNonZero, _) | (Input::Zero, Input::AnyNonZero) => Input::AnyNonZero,
                 _ => Input::Any,
             },
             dissatisfiable: left.dissatisfiable && right.dissatisfiable,
@@ -309,12 +308,11 @@ impl Property for Correctness {
             },
             input: match (left.input, right.input) {
                 (Input::Zero, Input::Zero) => Input::Zero,
-                (Input::Zero, Input::One)
-                    | (Input::One, Input::Zero) => Input::One,
-                (Input::Zero, Input::OneNonZero)
-                    | (Input::OneNonZero, Input::Zero) => Input::OneNonZero,
-                (Input::AnyNonZero, _)
-                    | (Input::Zero, Input::AnyNonZero) => Input::AnyNonZero,
+                (Input::Zero, Input::One) | (Input::One, Input::Zero) => Input::One,
+                (Input::Zero, Input::OneNonZero) | (Input::OneNonZero, Input::Zero) => {
+                    Input::OneNonZero
+                }
+                (Input::AnyNonZero, _) | (Input::Zero, Input::AnyNonZero) => Input::AnyNonZero,
                 _ => Input::Any,
             },
             dissatisfiable: false,
@@ -337,9 +335,9 @@ impl Property for Correctness {
             input: match (left.input, right.input) {
                 (Input::Zero, Input::Zero) => Input::Zero,
                 (Input::Zero, Input::One)
-                    | (Input::One, Input::Zero)
-                    | (Input::Zero, Input::OneNonZero)
-                    | (Input::OneNonZero, Input::Zero) => Input::One,
+                | (Input::One, Input::Zero)
+                | (Input::Zero, Input::OneNonZero)
+                | (Input::OneNonZero, Input::Zero) => Input::One,
                 _ => Input::Any,
             },
             dissatisfiable: true,
@@ -358,8 +356,7 @@ impl Property for Correctness {
             },
             input: match (left.input, right.input) {
                 (Input::Zero, Input::Zero) => Input::Zero,
-                (Input::One, Input::Zero)
-                    | (Input::OneNonZero, Input::Zero) => Input::One,
+                (Input::One, Input::Zero) | (Input::OneNonZero, Input::Zero) => Input::One,
                 _ => Input::Any,
             },
             dissatisfiable: right.dissatisfiable,
@@ -378,8 +375,7 @@ impl Property for Correctness {
             },
             input: match (left.input, right.input) {
                 (Input::Zero, Input::Zero) => Input::Zero,
-                (Input::One, Input::Zero)
-                    | (Input::OneNonZero, Input::Zero) => Input::One,
+                (Input::One, Input::Zero) | (Input::OneNonZero, Input::Zero) => Input::One,
                 _ => Input::Any,
             },
             dissatisfiable: right.dissatisfiable,
@@ -406,10 +402,10 @@ impl Property for Correctness {
 
     fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
         if !a.dissatisfiable {
-            return Err(ErrorKind::LeftNotDissatisfiable)
+            return Err(ErrorKind::LeftNotDissatisfiable);
         }
         if !a.unit {
-            return Err(ErrorKind::LeftNotUnit)
+            return Err(ErrorKind::LeftNotUnit);
         }
         Ok(Correctness {
             base: match (a.base, b.base, c.base) {
@@ -421,11 +417,11 @@ impl Property for Correctness {
             input: match (a.input, b.input, c.input) {
                 (Input::Zero, Input::Zero, Input::Zero) => Input::Zero,
                 (Input::Zero, Input::One, Input::One)
-                    | (Input::Zero, Input::One, Input::OneNonZero)
-                    | (Input::Zero, Input::OneNonZero, Input::One)
-                    | (Input::Zero, Input::OneNonZero, Input::OneNonZero)
-                    | (Input::One, Input::Zero, Input::Zero)
-                    | (Input::OneNonZero, Input::Zero, Input::Zero) => Input::One,
+                | (Input::Zero, Input::One, Input::OneNonZero)
+                | (Input::Zero, Input::OneNonZero, Input::One)
+                | (Input::Zero, Input::OneNonZero, Input::OneNonZero)
+                | (Input::One, Input::Zero, Input::Zero)
+                | (Input::OneNonZero, Input::Zero, Input::Zero) => Input::One,
                 _ => Input::Any,
             },
             dissatisfiable: c.dissatisfiable,
@@ -433,32 +429,28 @@ impl Property for Correctness {
         })
     }
 
-    fn threshold<S>(
-        k: usize,
-        n: usize,
-        mut sub_ck: S,
-    ) -> Result<Self, ErrorKind>
-    where S: FnMut(usize) -> Result<Self, ErrorKind>
+    fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
+    where
+        S: FnMut(usize) -> Result<Self, ErrorKind>,
     {
         let mut is_n = k == n;
         for i in 0..n {
             let subtype = sub_ck(i)?;
             if i == 0 {
-                is_n &= subtype.input == Input::OneNonZero
-                    || subtype.input == Input::AnyNonZero;
+                is_n &= subtype.input == Input::OneNonZero || subtype.input == Input::AnyNonZero;
                 if subtype.base != Base::B {
-                    return Err(ErrorKind::ThresholdBase(i, subtype.base))
+                    return Err(ErrorKind::ThresholdBase(i, subtype.base));
                 }
             } else {
                 if subtype.base != Base::W {
-                    return Err(ErrorKind::ThresholdBase(i, subtype.base))
+                    return Err(ErrorKind::ThresholdBase(i, subtype.base));
                 }
                 if !subtype.unit {
-                    return Err(ErrorKind::ThresholdNonUnit(n))
+                    return Err(ErrorKind::ThresholdNonUnit(n));
                 }
             }
             if !subtype.dissatisfiable {
-                return Err(ErrorKind::ThresholdDissat(n))
+                return Err(ErrorKind::ThresholdDissat(n));
             }
         }
 

--- a/src/miniscript/types/malleability.rs
+++ b/src/miniscript/types/malleability.rs
@@ -258,9 +258,7 @@ impl Property for Malleability {
                 _ => Dissat::Unknown,
             },
             safe: left.safe && right.safe,
-            non_malleable: left.non_malleable
-                && right.non_malleable
-                && (left.safe || right.safe),
+            non_malleable: left.non_malleable && right.non_malleable && (left.safe || right.safe),
         })
     }
 
@@ -281,12 +279,9 @@ impl Property for Malleability {
         })
     }
 
-    fn threshold<S>(
-        k: usize,
-        n: usize,
-        mut sub_ck: S,
-    ) -> Result<Self, ErrorKind>
-    where S: FnMut(usize) -> Result<Self, ErrorKind>
+    fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
+    where
+        S: FnMut(usize) -> Result<Self, ErrorKind>,
     {
         let mut safe_count = 0;
         let mut all_are_dissat_unique = true;
@@ -310,4 +305,3 @@ impl Property for Malleability {
         })
     }
 }
-

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -22,8 +22,8 @@
 use std::{error, fmt};
 
 use bitcoin;
-use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::util::psbt;
+use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use secp256k1;
 
 use BitcoinSig;
@@ -63,39 +63,33 @@ impl error::Error for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::InvalidSignature { pubkey, index } => {
-                write!(
-                    f,
-                    "PSBT: bad signature with key {} on input {}",
-                    pubkey.key,
-                    index
-                )
-            }
+            Error::InvalidSignature { pubkey, index } => write!(
+                f,
+                "PSBT: bad signature with key {} on input {}",
+                pubkey.key, index
+            ),
             Error::MissingWitness(index) => {
                 write!(f, "PSBT is missing witness for input {}", index)
             }
             Error::MissingWitnessScript(index) => {
                 write!(f, "PSBT is missing witness script for input {}", index)
             }
-            Error::WrongInputCount { in_tx, in_map } => {
-                write!(
-                    f,
-                    "PSBT had {} inputs in transaction but {} inputs in map",
-                    in_tx,
-                    in_map
-                )
-            }
-            Error::WrongSigHashFlag { required, got, pubkey, index } => {
-                write!(
-                    f,
-                    "PSBT: signature on input {} with key {} had \
-                     sighashflag {:?} rather than required {:?}",
-                    index,
-                    pubkey.key,
-                    got,
-                    required
-                )
-            }
+            Error::WrongInputCount { in_tx, in_map } => write!(
+                f,
+                "PSBT had {} inputs in transaction but {} inputs in map",
+                in_tx, in_map
+            ),
+            Error::WrongSigHashFlag {
+                required,
+                got,
+                pubkey,
+                index,
+            } => write!(
+                f,
+                "PSBT: signature on input {} with key {} had \
+                 sighashflag {:?} rather than required {:?}",
+                index, pubkey.key, got, required
+            ),
         }
     }
 }
@@ -121,7 +115,8 @@ fn sanity_check(psbt: &Psbt) -> Result<(), super::Error> {
         return Err(Error::WrongInputCount {
             in_tx: psbt.global.unsigned_tx.input.len(),
             in_map: psbt.inputs.len(),
-        }.into());
+        }
+        .into());
     }
 
     Ok(())
@@ -138,7 +133,8 @@ pub fn finalize(psbt: &mut Psbt) -> Result<(), super::Error> {
                     return Err(Error::InvalidSignature {
                         pubkey: *key,
                         index: n,
-                    }.into());
+                    }
+                    .into());
                 }
                 let (flag, sig) = rawsig.split_last().unwrap();
                 let flag = bitcoin::SigHashType::from_u32(*flag as u32);
@@ -147,14 +143,16 @@ pub fn finalize(psbt: &mut Psbt) -> Result<(), super::Error> {
                         required: target,
                         got: flag,
                         pubkey: *key,
-                        index :n,
-                    }.into());
+                        index: n,
+                    }
+                    .into());
                 }
                 if let Err(_) = secp256k1::Signature::from_der(sig) {
                     return Err(Error::InvalidSignature {
                         pubkey: *key,
                         index: n,
-                    }.into());
+                    }
+                    .into());
                 }
                 // TODO check signature
             }


### PR DESCRIPTION
2 commits:
- output of `cargo fmt`
- Adds cargo fmt check to travis. 

There were different commands for formatting check for 1.22.0 and other versions. I just added it for stable version.