### PR TITLE
Removed Ord/PartialOrd derive rules for types.

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -42,13 +42,14 @@ use self::satisfy::{Satisfiable, Satisfier};
 use self::types::Property;
 use miniscript::types::extra_props::ExtData;
 use miniscript::types::Type;
+use std::cmp;
 use std::sync::Arc;
 use MiniscriptKey;
 use {expression, ToHash160};
 use {Error, ToPublicKey};
 
 /// Top-level script AST type
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Hash)]
 pub struct Miniscript<Pk: MiniscriptKey> {
     ///A node in the Abstract Syntax Tree(
     pub node: decode::Terminal<Pk>,
@@ -57,6 +58,38 @@ pub struct Miniscript<Pk: MiniscriptKey> {
     ///Additional information helpful for extra analysis.
     pub ext: types::extra_props::ExtData,
 }
+
+/// `PartialOrd` of `Miniscript` must depend only on node and not the type information.
+/// The type information and extra_properties can be deterministically determined
+/// by the ast tree.
+impl<Pk: MiniscriptKey> PartialOrd for Miniscript<Pk> {
+    fn partial_cmp(&self, other: &Miniscript<Pk>) -> Option<cmp::Ordering> {
+        Some(self.node.cmp(&other.node))
+    }
+}
+
+/// `Ord` of `Miniscript` must depend only on node and not the type information.
+/// The type information and extra_properties can be deterministically determined
+/// by the ast tree.
+impl<Pk: MiniscriptKey> Ord for Miniscript<Pk> {
+    fn cmp(&self, other: &Miniscript<Pk>) -> cmp::Ordering {
+        self.node.cmp(&other.node)
+    }
+}
+
+/// `PartialEq` of `Miniscript` must depend only on node and not the type information.
+/// The type information and extra_properties can be deterministically determined
+/// by the ast tree.
+impl<Pk: MiniscriptKey> PartialEq for Miniscript<Pk> {
+    fn eq(&self, other: &Miniscript<Pk>) -> bool {
+        self.node.eq(&other.node)
+    }
+}
+
+/// `Eq` of `Miniscript` must depend only on node and not the type information.
+/// The type information and extra_properties can be deterministically determined
+/// by the ast tree.
+impl<Pk: MiniscriptKey> Eq for Miniscript<Pk> {}
 
 impl<Pk: MiniscriptKey> fmt::Debug for Miniscript<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
- Added custom Eq/PartialEq for miniscript
- Removed Ord/PartialOrd derive rules for types.