### PR TITLE
Included wrappers for `l`,`u`,`t`.

### DIFF
--- a/src/descriptor/satisfied_constraints.rs
+++ b/src/descriptor/satisfied_constraints.rs
@@ -1233,11 +1233,7 @@ mod tests {
             StackElement::Push(&preimage),
             StackElement::Push(&der_sigs[0]),
         ]);
-        let elem = ms_str!(
-            "and_b(c:pk({}),sj:and_v(v:sha256({}),true))",
-            pks[0],
-            sha256_hash
-        );
+        let elem = ms_str!("and_b(c:pk({}),sjtv:sha256({}))", pks[0], sha256_hash);
         let constraints = from_stack(&vfyfn, stack, &elem);
 
         let and_b_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1261,10 +1257,10 @@ mod tests {
             StackElement::Push(&der_sigs[0]),
         ]);
         let elem = ms_str!(
-            "and_or(c:pk({}),c:pk_h({}),j:and_v(v:sha256({}),true))",
+            "andor(c:pk({}),jtv:sha256({}),c:pk_h({}))",
             pks[0],
+            sha256_hash,
             pks[1].to_pubkeyhash(),
-            sha256_hash
         );
         let constraints = from_stack(&vfyfn, stack, &elem);
 
@@ -1307,11 +1303,7 @@ mod tests {
             StackElement::Push(&preimage),
             StackElement::Dissatisfied,
         ]);
-        let elem = ms_str!(
-            "or_b(c:pk({}),sj:and_v(v:sha256({}),true))",
-            pks[0],
-            sha256_hash
-        );
+        let elem = ms_str!("or_b(c:pk({}),sjtv:sha256({}))", pks[0], sha256_hash);
         let constraints = from_stack(&vfyfn, stack, &elem);
 
         let or_b_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1325,11 +1317,7 @@ mod tests {
 
         //Check OrD
         let stack = Stack(vec![StackElement::Push(&der_sigs[0])]);
-        let elem = ms_str!(
-            "or_d(c:pk({}),j:and_v(v:sha256({}),true))",
-            pks[0],
-            sha256_hash
-        );
+        let elem = ms_str!("or_d(c:pk({}),jtv:sha256({}))", pks[0], sha256_hash);
         let constraints = from_stack(&vfyfn, stack, &elem);
 
         let or_d_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1346,11 +1334,7 @@ mod tests {
             StackElement::Push(&der_sigs[0]),
             StackElement::Dissatisfied,
         ]);
-        let elem = ms_str!(
-            "and_v(or_c(j:and_v(v:sha256({}),true),vc:pk({})),true)",
-            sha256_hash,
-            pks[0]
-        );
+        let elem = ms_str!("t:or_c(jtv:sha256({}),vc:pk({}))", sha256_hash, pks[0]);
         let constraints = from_stack(&vfyfn, stack, &elem);
 
         let or_c_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1367,11 +1351,7 @@ mod tests {
             StackElement::Push(&der_sigs[0]),
             StackElement::Dissatisfied,
         ]);
-        let elem = ms_str!(
-            "or_i(j:and_v(v:sha256({}),true),c:pk({}))",
-            sha256_hash,
-            pks[0]
-        );
+        let elem = ms_str!("or_i(jtv:sha256({}),c:pk({}))", sha256_hash, pks[0]);
         let constraints = from_stack(&vfyfn, stack, &elem);
 
         let or_i_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl MiniscriptKey for String {
     type Hash = String;
 
     fn to_pubkeyhash(&self) -> Self::Hash {
-        format!("hash({})", &self)
+        format!("{}", &self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,8 +279,10 @@ pub enum Error {
     MultiAt(String),
     /// Name of a fragment contained `@` but we were not parsing an OR
     AtOutsideOr(String),
-    /// Fragment was an `and_v(_, true())` which should be written as `t:`
+    /// Fragment was an `and_v(_, true)` which should be written as `t:`
     NonCanonicalTrue,
+    /// Fragment was an `or_i(_, false)` or `or_i(false,_)` which should be written as `u:` or `l:`
+    NonCanonicalFalse,
     /// Encountered a wrapping character that we don't recognize
     UnknownWrapper(char),
     /// Parsed a miniscript and the result was not of type T
@@ -371,6 +373,9 @@ impl fmt::Display for Error {
             Error::MultiAt(ref s) => write!(f, "«{}» has multiple instances of «@»", s),
             Error::AtOutsideOr(ref s) => write!(f, "«{}» contains «@» in non-or() context", s),
             Error::NonCanonicalTrue => f.write_str("Use «t:X» rather than «and_v(X,true())»"),
+            Error::NonCanonicalFalse => {
+                f.write_str("Use «u:X» «l:X» rather than «or_i(X,false)» «or_i(false,X)»")
+            }
             Error::UnknownWrapper(ch) => write!(f, "unknown wrapper «{}:»", ch),
             Error::NonTopLevel(ref s) => write!(f, "non-T miniscript: {}", s),
             Error::Trailing(ref s) => write!(f, "trailing tokens: {}", s),

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -49,7 +49,10 @@ impl<Pk: MiniscriptKey> Terminal<Pk> {
             Terminal::DupIf(ref sub) => Some(('d', sub)),
             Terminal::Verify(ref sub) => Some(('v', sub)),
             Terminal::NonZero(ref sub) => Some(('j', sub)),
-            Terminal::ZeroNotEqual(ref sub) => Some(('u', sub)),
+            Terminal::ZeroNotEqual(ref sub) => Some(('n', sub)),
+            Terminal::AndV(ref sub, ref r) if r.node == Terminal::True => Some(('t', sub)),
+            Terminal::OrI(ref sub, ref r) if r.node == Terminal::False => Some(('u', sub)),
+            Terminal::OrI(ref l, ref sub) if l.node == Terminal::False => Some(('l', sub)),
             _ => None,
         }
     }
@@ -207,7 +210,11 @@ impl<Pk: MiniscriptKey> fmt::Debug for Terminal<Pk> {
                 Terminal::AndV(ref l, ref r) => write!(f, "and_v({:?},{:?})", l, r),
                 Terminal::AndB(ref l, ref r) => write!(f, "and_b({:?},{:?})", l, r),
                 Terminal::AndOr(ref a, ref b, ref c) => {
-                    write!(f, "and_or({:?},{:?},{:?})", a, c, b)
+                    if c.node == Terminal::False {
+                        write!(f, "and_n({:?},{:?})", a, b)
+                    } else {
+                        write!(f, "andor({:?},{:?},{:?})", a, b, c)
+                    }
                 }
                 Terminal::OrB(ref l, ref r) => write!(f, "or_b({:?},{:?})", l, r),
                 Terminal::OrD(ref l, ref r) => write!(f, "or_d({:?},{:?})", l, r),
@@ -246,13 +253,25 @@ impl<Pk: MiniscriptKey> fmt::Display for Terminal<Pk> {
             Terminal::Hash160(h) => write!(f, "hash160({})", h),
             Terminal::True => f.write_str("1"),
             Terminal::False => f.write_str("0"),
-            Terminal::AndV(ref l, ref r) => write!(f, "and_v({},{})", l, r),
+            Terminal::AndV(ref l, ref r) if r.node != Terminal::True => {
+                write!(f, "and_v({},{})", l, r)
+            }
             Terminal::AndB(ref l, ref r) => write!(f, "and_b({},{})", l, r),
-            Terminal::AndOr(ref a, ref b, ref c) => write!(f, "tern({},{},{})", a, c, b),
+            Terminal::AndOr(ref a, ref b, ref c) => {
+                if c.node == Terminal::False {
+                    write!(f, "and_n({},{})", a, b)
+                } else {
+                    write!(f, "andor({},{},{})", a, b, c)
+                }
+            }
             Terminal::OrB(ref l, ref r) => write!(f, "or_b({},{})", l, r),
             Terminal::OrD(ref l, ref r) => write!(f, "or_d({},{})", l, r),
             Terminal::OrC(ref l, ref r) => write!(f, "or_c({},{})", l, r),
-            Terminal::OrI(ref l, ref r) => write!(f, "or_i({},{})", l, r),
+            Terminal::OrI(ref l, ref r)
+                if l.node != Terminal::False && r.node != Terminal::False =>
+            {
+                write!(f, "or_i({},{})", l, r)
+            }
             Terminal::Thresh(k, ref subs) => {
                 write!(f, "thresh({}", k)?;
                 for s in subs {
@@ -345,17 +364,39 @@ where
                 hash160::Hash::from_hex(x).map(Terminal::Hash160)
             }),
             ("true", 0) => Ok(Terminal::True),
-            ("and_v", 2) => expression::binary(top, Terminal::AndV),
+            ("false", 0) => Ok(Terminal::False),
+            ("and_v", 2) => {
+                let expr = expression::binary(top, Terminal::AndV)?;
+                if let Terminal::AndV(_, ref right) = expr {
+                    if let Terminal::True = right.node {
+                        return Err(Error::NonCanonicalTrue);
+                    }
+                }
+                Ok(expr)
+            }
             ("and_b", 2) => expression::binary(top, Terminal::AndB),
-            ("and_or", 3) => Ok(Terminal::AndOr(
+            ("and_n", 2) => Ok(Terminal::AndOr(
                 expression::FromTree::from_tree(&top.args[0])?,
-                expression::FromTree::from_tree(&top.args[2])?,
                 expression::FromTree::from_tree(&top.args[1])?,
+                Arc::new(Miniscript::from_ast(Terminal::False)?),
+            )),
+            ("andor", 3) => Ok(Terminal::AndOr(
+                expression::FromTree::from_tree(&top.args[0])?,
+                expression::FromTree::from_tree(&top.args[1])?,
+                expression::FromTree::from_tree(&top.args[2])?,
             )),
             ("or_b", 2) => expression::binary(top, Terminal::OrB),
             ("or_d", 2) => expression::binary(top, Terminal::OrD),
             ("or_c", 2) => expression::binary(top, Terminal::OrC),
-            ("or_i", 2) => expression::binary(top, Terminal::OrI),
+            ("or_i", 2) => {
+                let expr = expression::binary(top, Terminal::OrI)?;
+                if let Terminal::OrI(ref left, ref right) = expr {
+                    if left.node == Terminal::False || right.node == Terminal::False {
+                        return Err(Error::NonCanonicalFalse);
+                    }
+                }
+                Ok(expr)
+            }
             ("thresh", n) => {
                 let k = expression::terminal(&top.args[0], expression::parse_num)? as usize;
                 if n == 0 || k > n - 1 {
@@ -399,8 +440,26 @@ where
                 'd' => unwrapped = Terminal::DupIf(Arc::new(Miniscript::from_ast(unwrapped)?)),
                 'v' => unwrapped = Terminal::Verify(Arc::new(Miniscript::from_ast(unwrapped)?)),
                 'j' => unwrapped = Terminal::NonZero(Arc::new(Miniscript::from_ast(unwrapped)?)),
-                'u' => {
+                'n' => {
                     unwrapped = Terminal::ZeroNotEqual(Arc::new(Miniscript::from_ast(unwrapped)?))
+                }
+                't' => {
+                    unwrapped = Terminal::AndV(
+                        Arc::new(Miniscript::from_ast(unwrapped)?),
+                        Arc::new(Miniscript::from_ast(Terminal::True)?),
+                    )
+                }
+                'u' => {
+                    unwrapped = Terminal::OrI(
+                        Arc::new(Miniscript::from_ast(unwrapped)?),
+                        Arc::new(Miniscript::from_ast(Terminal::False)?),
+                    )
+                }
+                'l' => {
+                    unwrapped = Terminal::OrI(
+                        Arc::new(Miniscript::from_ast(Terminal::False)?),
+                        Arc::new(Miniscript::from_ast(unwrapped)?),
+                    )
                 }
                 x => return Err(Error::UnknownWrapper(x)),
             }


### PR DESCRIPTION
Changed the naming to be consistent with bitcoin.sipa.be/miniscript