### PR TITLE
Removed Pkh Type from concrete policies

### DIFF
--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -616,12 +616,6 @@ fn best_compilations<Pk: MiniscriptKey>(
             sat_prob,
             dissat_prob,
         ),
-        Concrete::KeyHash(ref pkh) => insert_best_wrapped(
-            &mut ret,
-            AstElemExt::terminal(Terminal::PkH(pkh.clone())),
-            sat_prob,
-            dissat_prob,
-        ),
         Concrete::After(n) => {
             insert_best_wrapped(
                 &mut ret,
@@ -943,11 +937,6 @@ mod tests {
     #[test]
     fn compile_basic() {
         let policy = DummyPolicy::from_str("pk()").expect("parse");
-        let miniscript = policy.compile();
-        assert_eq!(policy.lift(), Semantic::KeyHash(DummyKeyHash));
-        assert_eq!(miniscript.lift(), Semantic::KeyHash(DummyKeyHash));
-
-        let policy = DummyPolicy::from_str("pkh()").expect("parse");
         let miniscript = policy.compile();
         assert_eq!(policy.lift(), Semantic::KeyHash(DummyKeyHash));
         assert_eq!(miniscript.lift(), Semantic::KeyHash(DummyKeyHash));

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -125,7 +125,6 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
     fn lift(&self) -> Semantic<Pk> {
         match *self {
             Concrete::Key(ref pk) => Semantic::KeyHash(pk.to_pubkeyhash()),
-            Concrete::KeyHash(ref pkh) => Semantic::KeyHash(pkh.clone()),
             Concrete::After(t) => Semantic::After(t),
             Concrete::Older(t) => Semantic::Older(t),
             Concrete::Sha256(h) => Semantic::Sha256(h),


### PR DESCRIPTION
Users should not provide `Pkh` input to the policy file. 