### PR TITLE
Add failing test case for HTLC script

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -874,4 +874,9 @@ mod tests {
                 .into_script()
         );
     }
+
+    #[test]
+    fn htlc() {
+        Descriptor::<bitcoin::PublicKey>::from_str("c:or_i(and_v(v:sha256(0000000000000000000000000000000000000000000000000000000000000000),pk_h(1111111111111111111111111111111111111111)),and_v(after(3333333),pk_h(2222222222222222222222222222222222222222)))").expect("htlc should be valid descriptor");
+    }
 }


### PR DESCRIPTION
According to http://bitcoin.sipa.be/miniscript/, the following is a valid miniscript:
`c:or_i(and_v(v:sha256(0000000000000000000000000000000000000000000000000000000000000000),pk_h(A)),and_v(after(3333333),pk_h(B)))`

Now if I plug that into the `Descriptor` type and replace `A` and `B` with data of the correct length, I get the following error:

```
TypeCheck("fragment «and_v(after(3333333),pk_h(2222222222222222222222222222222222222222))» cannot accept children of types B and K"
```

Is this a bug or am I creating the HTLC wrong with miniscript?

Thanks in advance!