### PR TITLE
Example weight estimation for multisig

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -26,6 +26,13 @@ do
     cargo test --verbose --features="$feature"
 done
 
+# Also build and run each example to catch regressions
+cargo build --examples
+./target/debug/examples/htlc
+./target/debug/examples/parse
+./target/debug/examples/sign_multisig
+./target/debug/examples/verify_tx
+
 # Fuzz if told to
 if [ "$DO_FUZZ" = true ]
 then

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -82,6 +82,11 @@ fn main() {
     let my_descriptor =
         BitcoinDescriptor::from_str(&descriptor_str[..]).expect("parse descriptor string");
 
+    // Check weight for witness satisfaction cost ahead of time.
+    // 4(scriptSig length of 0) + 1(witness stack size) + 106(serialized witnessScript)
+    // + 73*2(signature length + signatures + sighash bytes) + 1(dummy byte) = 258
+    assert_eq!(my_descriptor.max_satisfaction_weight(), 258);
+
     // Observe the script properties, just for fun
     assert_eq!(
         format!("{:x}", my_descriptor.script_pubkey()),


### PR DESCRIPTION
Also added each current example to Travis to avoid unnecessary regressions.

`max_satisfaction_weight` needs real tests, but this can be done later.