### PR TITLE
Cure RAS Syndrome

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-//! # AST Tree
+//! # Abstract Syntax Tree
 //!
 //! Defines a variety of data structures for describing Miniscript, a subset of
 //! Bitcoin Script which can be efficiently parsed and serialized from Script,
@@ -21,7 +21,7 @@
 //! Users of the library in general will only need to use the structures exposed
 //! from the top level of this module; however for people wanting to do advanced
 //! things, the submodules are public as well which provide visibility into the
-//! components of the AST trees.
+//! components of the AST.
 //!
 
 #[cfg(feature = "serde")]
@@ -59,7 +59,7 @@ pub struct Miniscript<Pk: MiniscriptKey> {
 
 /// `PartialOrd` of `Miniscript` must depend only on node and not the type information.
 /// The type information and extra_properties can be deterministically determined
-/// by the ast tree.
+/// by the ast.
 impl<Pk: MiniscriptKey> PartialOrd for Miniscript<Pk> {
     fn partial_cmp(&self, other: &Miniscript<Pk>) -> Option<cmp::Ordering> {
         Some(self.node.cmp(&other.node))
@@ -68,7 +68,7 @@ impl<Pk: MiniscriptKey> PartialOrd for Miniscript<Pk> {
 
 /// `Ord` of `Miniscript` must depend only on node and not the type information.
 /// The type information and extra_properties can be deterministically determined
-/// by the ast tree.
+/// by the ast.
 impl<Pk: MiniscriptKey> Ord for Miniscript<Pk> {
     fn cmp(&self, other: &Miniscript<Pk>) -> cmp::Ordering {
         self.node.cmp(&other.node)
@@ -77,7 +77,7 @@ impl<Pk: MiniscriptKey> Ord for Miniscript<Pk> {
 
 /// `PartialEq` of `Miniscript` must depend only on node and not the type information.
 /// The type information and extra_properties can be deterministically determined
-/// by the ast tree.
+/// by the ast.
 impl<Pk: MiniscriptKey> PartialEq for Miniscript<Pk> {
     fn eq(&self, other: &Miniscript<Pk>) -> bool {
         self.node.eq(&other.node)
@@ -86,7 +86,7 @@ impl<Pk: MiniscriptKey> PartialEq for Miniscript<Pk> {
 
 /// `Eq` of `Miniscript` must depend only on node and not the type information.
 /// The type information and extra_properties can be deterministically determined
-/// by the ast tree.
+/// by the ast.
 impl<Pk: MiniscriptKey> Eq for Miniscript<Pk> {}
 
 impl<Pk: MiniscriptKey> fmt::Debug for Miniscript<Pk> {


### PR DESCRIPTION
From https://en.wikipedia.org/wiki/RAS_syndrome

> RAS syndrome (where "RAS" stands for "redundant acronym syndrome",
making the phrase "RAS syndrome" self-referential) is the use of one
or more of the words that make up an acronym (or other initialism) in
conjunction with the abbreviated form.