### PR TITLE
Miniscript produces witness stacks with wrong order of signatures for `and` instructions

### DIFF
--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -580,7 +580,7 @@ impl Satisfaction {
                 let l_sat = Self::satisfy(&l.node, stfr);
                 let r_sat = Self::satisfy(&r.node, stfr);
                 Satisfaction {
-                    stack: Witness::combine(l_sat.stack, r_sat.stack),
+                    stack: Witness::combine(r_sat.stack, l_sat.stack),
                     has_sig: l_sat.has_sig || r_sat.has_sig,
                 }
             }
@@ -592,11 +592,11 @@ impl Satisfaction {
 
                 Self::minimum(
                     Satisfaction {
-                        stack: Witness::combine(a_sat.stack, b_sat.stack),
+                        stack: Witness::combine(b_sat.stack, a_sat.stack),
                         has_sig: a_sat.has_sig || b_sat.has_sig,
                     },
                     Satisfaction {
-                        stack: Witness::combine(a_nsat.stack, c_sat.stack),
+                        stack: Witness::combine(c_sat.stack, a_nsat.stack),
                         has_sig: a_nsat.has_sig || c_sat.has_sig,
                     },
                 )


### PR DESCRIPTION
Given an `and` instruction, miniscript produces a witness stack that
is wrongly ordered:

The left branch of an `and` instruction is evaluated first, which means
whatever witness stack is produced by this branch needs to come _after_
the witness stack of the right branch.

Unfortunately, Witness::combine simply concatenates the two vectors,
resulting in the witness stack for the left branch to end up _before_ the
one for the right branch.

This is what we currently have:

```
Witness in memory:

|----A-----|----B-----|--and(A,B)--|

Witness stack evaluation:

Round 0:
        Stack:          Instructions:

                        check(A) check(B)
        |----B-----|
        |----A-----|

Round 1:
        Stack:          Instructions:

                        |----B-----| check(A) check(B)
        |----A-----|

Round 2:
        Failure due to wrong signature.
```

With this patch, this changes to what we actually want:

```
Witness in memory:

|----B-----|----A-----|--and(A,B)--|

Witness stack evaluation:

Round 0:
        Stack:          Instructions:

                        check(A) check(B)
        |----A-----|
        |----B-----|

Round 1:
        Stack:          Instructions:

                        |----A-----| check(A) check(B)
        |----B-----|

Round 2:
        Stack:          Instructions:

                        check(B)
        |----B-----|

Round 3:
        Stack:          Instructions:

                        |----B-----| check(B)

Round 4:
        Script successfully executed!
```

This PR is branched of the 0.12.0 tag because we couldn't make the descriptor parsing work with latest master. It seems that there are some bigger changes incoming.

I also don't know, for which other instructions this behaviour also applies but I guess it might actually apply to all combinators.

We tested this against bitcoind 0.19.1.

Co-authored-by: Lucas Soriano del Pino <l.soriano.del.pino@gmail.com>