### PR TITLE
Add clarification on 2015 edition usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 **Minimum Supported Rust Version:** 1.22.0
 
+*This crate uses "2015" edition and won't be ported over "2018" edition
+in the near future as this will change the MSRV to 1.31.*
+
 # Miniscript
 
 Library for handling [Miniscript](http://bitcoin.sipa.be/miniscript/),


### PR DESCRIPTION
I was wondering why this crate isn't using the 2018 edition yet.

More details can be found in the discussion for #34:

* https://github.com/apoelstra/rust-miniscript/pull/34#issuecomment-524173776
* https://github.com/apoelstra/rust-miniscript/pull/34#issuecomment-524419649

Or in https://github.com/rust-bitcoin/rust-bitcoin/issues/338