### PR TITLE
Do not allow uncompressed pubkey in `wpkh(KEY)` output descriptor

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -405,7 +405,7 @@ where
                         Ok(Descriptor::ShWsh(sub))
                     }
                     ("wpkh", 1) => expression::terminal(&newtop.args[0], |pk| {
-                        str::FromStr::from_str(pk).map(Descriptor::ShWpkh)
+                        MiniscriptKey::from_str(pk, true).map(Descriptor::ShWpkh)
                     }),
                     _ => {
                         let sub = Miniscript::from_tree(&top.args[0])?;

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -364,9 +364,9 @@ where
             }
         }
         let mut unwrapped = match (frag_name, top.args.len()) {
-            ("pk_k", 1) => {
-                expression::terminal(&top.args[0], |x| Pk::from_str(x).map(Terminal::PkK))
-            }
+            ("pk_k", 1) => expression::terminal(&top.args[0], |x| {
+                str::FromStr::from_str(x).map(Terminal::PkK)
+            }),
             ("pk_h", 1) => {
                 expression::terminal(&top.args[0], |x| Pk::Hash::from_str(x).map(Terminal::PkH))
             }
@@ -458,7 +458,7 @@ where
 
                 let pks: Result<Vec<Pk>, _> = top.args[1..]
                     .iter()
-                    .map(|sub| expression::terminal(sub, Pk::from_str))
+                    .map(|sub| expression::terminal(sub, str::FromStr::from_str))
                     .collect();
 
                 pks.map(|pks| Terminal::Multi(k, pks))

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -365,7 +365,7 @@ where
         }
         let mut unwrapped = match (frag_name, top.args.len()) {
             ("pk_k", 1) => expression::terminal(&top.args[0], |x| {
-                str::FromStr::from_str(x).map(Terminal::PkK)
+                MiniscriptKey::from_str(x, false).map(Terminal::PkK)
             }),
             ("pk_h", 1) => {
                 expression::terminal(&top.args[0], |x| Pk::Hash::from_str(x).map(Terminal::PkH))

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -498,10 +498,11 @@ mod tests {
 
     #[test]
     fn basic() {
-        let pk = bitcoin::PublicKey::from_str(
+        let pk = MiniscriptKey::from_str(
             "\
              020202020202020202020202020202020202020202020202020202020202020202\
              ",
+            false,
         )
         .unwrap();
         let hash = hash160::Hash::from_inner([17; 20]);
@@ -586,7 +587,7 @@ mod tests {
 
         string_rtt(
             script,
-            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, key: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })", 
+            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, key: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "pk(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)"
         );
 
@@ -594,7 +595,7 @@ mod tests {
 
         string_rtt(
             script,
-            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, key: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })", 
+            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, key: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "pk(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)"
         );
     }

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -381,7 +381,9 @@ where
             }
         }
         match (frag_name, top.args.len() as u32) {
-            ("pk", 1) => expression::terminal(&top.args[0], |pk| Pk::from_str(pk).map(Policy::Key)),
+            ("pk", 1) => expression::terminal(&top.args[0], |pk| {
+                str::FromStr::from_str(pk).map(Policy::Key)
+            }),
             ("after", 1) => expression::terminal(&top.args[0], |x| {
                 expression::parse_num(x).map(Policy::After)
             }),

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -382,7 +382,7 @@ where
         }
         match (frag_name, top.args.len() as u32) {
             ("pk", 1) => expression::terminal(&top.args[0], |pk| {
-                str::FromStr::from_str(pk).map(Policy::Key)
+                MiniscriptKey::from_str(pk, false).map(Policy::Key)
             }),
             ("after", 1) => expression::terminal(&top.args[0], |x| {
                 expression::parse_num(x).map(Policy::After)


### PR DESCRIPTION
> wpkh(KEY) (not inside wsh): P2WPKH output for the given compressed pubkey.