### PR TITLE
Add ScriptContext to Miniscript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       env: DO_FUZZ=true DO_LINT=true
     - rust: beta
     - rust: nightly
-      env: DO_BENCH=true
+      env: DO_BENCH=true DO_MIRI=true
     - rust: 1.22.0
 
 script:

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -43,6 +43,23 @@ then
     )
 fi
 
+# Miri Checks if told to
+# Only supported in nightly
+if [ "$DO_MIRI" = true ]
+then
+    (
+        MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+        echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+        rustup set profile minimal
+        rustup default "$MIRI_NIGHTLY"
+        rustup component add miri
+        cargo miri test -- -- miri_
+
+        # Change back to latest nightly possibly without Miri
+        rustup default nightly
+    )
+fi
+
 # Bench if told to
 if [ "$DO_BENCH" = true ]
 then

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -103,7 +103,6 @@ fn main() {
         0,
         0,
     );
-
     println!("\nExample one");
     for elem in iter {
         match elem.expect("no evaluation error") {
@@ -129,7 +128,6 @@ fn main() {
         0,
         0,
     );
-
     println!("\nExample two");
     for elem in iter {
         match elem.expect("no evaluation error") {
@@ -154,7 +152,6 @@ fn main() {
         0,
         0,
     );
-
     println!("\nExample three");
     for elem in iter {
         let error = elem.expect_err("evaluation error");

--- a/fuzz/fuzz_targets/compile_descriptor.rs
+++ b/fuzz/fuzz_targets/compile_descriptor.rs
@@ -1,18 +1,19 @@
 extern crate miniscript;
 
+use miniscript::Segwitv0;
 use miniscript::{policy, DummyKey, Miniscript};
 use policy::Liftable;
 
 use std::str::FromStr;
 
-type DummyScript = Miniscript<DummyKey>;
+type DummyScript = Miniscript<DummyKey, Segwitv0>;
 type DummyPolicy = policy::Concrete<DummyKey>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
     if let Ok(pol) = DummyPolicy::from_str(&data_str) {
         // Compile
-        if let Ok(desc) = pol.compile() {
+        if let Ok(desc) = pol.compile::<Segwitv0>() {
             // Lift
             assert_eq!(desc.clone().lift(), pol.clone().lift());
             // Try to roundtrip the output of the compiler
@@ -37,7 +38,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
     loop {

--- a/fuzz/fuzz_targets/roundtrip_concrete.rs
+++ b/fuzz/fuzz_targets/roundtrip_concrete.rs
@@ -1,9 +1,8 @@
-
 extern crate miniscript;
 extern crate regex;
-use std::str::FromStr;
 use miniscript::{policy, DummyKey};
 use regex::Regex;
+use std::str::FromStr;
 
 type DummyPolicy = policy::Concrete<DummyKey>;
 
@@ -29,7 +28,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
     loop {

--- a/fuzz/fuzz_targets/roundtrip_descriptor.rs
+++ b/fuzz/fuzz_targets/roundtrip_descriptor.rs
@@ -1,4 +1,3 @@
-
 extern crate miniscript;
 extern crate regex;
 
@@ -10,13 +9,15 @@ fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
     if let Ok(desc) = Descriptor::<DummyKey>::from_str(&s) {
         let output = desc.to_string();
-        
+
         let multi_wrap_pk_re = Regex::new("([a-z]+)c:pk_k\\(").unwrap();
         let multi_wrap_pkh_re = Regex::new("([a-z]+)c:pk_h\\(").unwrap();
 
         let normalize_aliases = multi_wrap_pk_re.replace_all(&s, "$1:pk(");
         let normalize_aliases = multi_wrap_pkh_re.replace_all(&normalize_aliases, "$1:pkh(");
-        let normalize_aliases = normalize_aliases.replace("c:pk_k(", "pk(").replace("c:pk_h(", "pkh(");
+        let normalize_aliases = normalize_aliases
+            .replace("c:pk_k(", "pk(")
+            .replace("c:pk_h(", "pkh(");
 
         assert_eq!(normalize_aliases.to_lowercase(), output.to_lowercase());
     }
@@ -32,7 +33,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
     loop {

--- a/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
@@ -1,14 +1,14 @@
-
 extern crate miniscript;
 
-use miniscript::Miniscript;
 use miniscript::bitcoin::blockdata::script;
+use miniscript::Miniscript;
+use miniscript::Segwitv0;
 
 fn do_test(data: &[u8]) {
     // Try round-tripping as a script
     let script = script::Script::from(data.to_owned());
 
-    if let Ok(pt) = Miniscript::parse(&script) {
+    if let Ok(pt) = Miniscript::<_, Segwitv0>::parse(&script) {
         let output = pt.encode();
         assert_eq!(pt.script_size(), output.len());
         assert_eq!(output, script);
@@ -25,7 +25,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
     loop {

--- a/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
@@ -1,27 +1,28 @@
-
 extern crate miniscript;
 extern crate regex;
 
-use std::str::FromStr;
 use regex::Regex;
+use std::str::FromStr;
 
-use miniscript::{DummyKey};
+use miniscript::DummyKey;
 use miniscript::Miniscript;
+use miniscript::Segwitv0;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
-    if let Ok(desc) = Miniscript::<DummyKey>::from_str(&s) {
+    if let Ok(desc) = Miniscript::<DummyKey, Segwitv0>::from_str(&s) {
         let output = desc.to_string();
-        
+
         let multi_wrap_pk_re = Regex::new("([a-z]+)c:pk_k\\(").unwrap();
         let multi_wrap_pkh_re = Regex::new("([a-z]+)c:pk_h\\(").unwrap();
 
         let normalize_aliases = multi_wrap_pk_re.replace_all(&s, "$1:pk(");
         let normalize_aliases = multi_wrap_pkh_re.replace_all(&normalize_aliases, "$1:pkh(");
-        let normalize_aliases = normalize_aliases.replace("c:pk_k(", "pk(").replace("c:pk_h(", "pkh(");
+        let normalize_aliases = normalize_aliases
+            .replace("c:pk_k(", "pk(")
+            .replace("c:pk_h(", "pkh(");
 
         assert_eq!(normalize_aliases.to_lowercase(), output.to_lowercase());
-
     }
 }
 
@@ -35,7 +36,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
     loop {

--- a/fuzz/fuzz_targets/roundtrip_semantic.rs
+++ b/fuzz/fuzz_targets/roundtrip_semantic.rs
@@ -1,8 +1,7 @@
-
 extern crate miniscript;
 
-use std::str::FromStr;
 use miniscript::{policy, DummyKey};
+use std::str::FromStr;
 
 type DummyPolicy = policy::Semantic<DummyKey>;
 
@@ -24,7 +23,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
     loop {

--- a/src/descriptor/create_descriptor.rs
+++ b/src/descriptor/create_descriptor.rs
@@ -9,7 +9,7 @@ use bitcoin::blockdata::script::Instruction;
 use descriptor::satisfied_constraints::Error as IntError;
 use descriptor::satisfied_constraints::{Stack, StackElement};
 use descriptor::Descriptor;
-use miniscript::Miniscript;
+use miniscript::{Legacy, Miniscript, Segwitv0};
 use Error;
 use ToPublicKey;
 
@@ -112,7 +112,7 @@ fn verify_wsh<'txin>(
     script_pubkey: &bitcoin::Script,
     script_sig: &bitcoin::Script,
     witness: &'txin [Vec<u8>],
-) -> Result<(Miniscript<bitcoin::PublicKey>, Stack<'txin>), Error> {
+) -> Result<(Miniscript<bitcoin::PublicKey, Segwitv0>, Stack<'txin>), Error> {
     if !script_sig.is_empty() {
         return Err(Error::NonEmptyScriptSig);
     }
@@ -121,7 +121,7 @@ fn verify_wsh<'txin>(
         if witness_script.to_v0_p2wsh() != *script_pubkey {
             return Err(Error::IncorrectScriptHash);
         }
-        let ms = Miniscript::parse(&witness_script)?;
+        let ms = Miniscript::<bitcoin::PublicKey, Segwitv0>::parse(&witness_script)?;
         //only iter till len -1 to not include the witness script
         let stack: Vec<StackElement> = witness
             .iter()
@@ -218,7 +218,7 @@ pub fn from_txin_with_witness_stack<'txin>(
             if !witness.is_empty() {
                 return Err(Error::NonEmptyWitness);
             }
-            let ms = Miniscript::parse(&redeem_script)?;
+            let ms = Miniscript::<bitcoin::PublicKey, Legacy>::parse(&redeem_script)?;
             Ok((Descriptor::Sh(ms), stack))
         }
     } else {
@@ -230,7 +230,7 @@ pub fn from_txin_with_witness_stack<'txin>(
         if !witness.is_empty() {
             return Err(Error::NonEmptyWitness);
         }
-        let ms = Miniscript::parse(script_pubkey)?;
+        let ms = Miniscript::<bitcoin::PublicKey, Legacy>::parse(script_pubkey)?;
         Ok((Descriptor::Bare(ms), Stack(stack?)))
     }
 }

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -1,0 +1,198 @@
+// Miniscript
+// Written in 2019 by
+//     Sanket Kanjalkar and Andrew Poelstra
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use std::fmt;
+use {Miniscript, MiniscriptKey, Terminal};
+
+/// Error for Script Context
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum ScriptContextError {
+    /// Script Context does not permit PkH for non-malleability
+    /// It is not possible to estimate the pubkey size at the creation
+    /// time because of uncompressed pubkeys
+    MalleablePkH,
+    /// Script Context does not permit OrI for non-malleability
+    /// Legacy fragments allow non-minimal IF which results in malleability
+    MalleableOrI,
+    /// Script Context does not permit DupIf for non-malleability
+    /// Legacy fragments allow non-minimal IF which results in malleability
+    MalleableDupIf,
+    /// Only Compressed keys allowed under current descriptor
+    /// Segwitv0 fragments do not allow uncompressed pubkeys
+    CompressedOnly,
+}
+
+impl fmt::Display for ScriptContextError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ScriptContextError::MalleablePkH => write!(f, "PkH is malleable under Legacy rules"),
+            ScriptContextError::MalleableOrI => write!(f, "OrI is malleable under Legacy rules"),
+            ScriptContextError::MalleableDupIf => {
+                write!(f, "DupIf is malleable under Legacy rules")
+            }
+            ScriptContextError::CompressedOnly => {
+                write!(f, "Uncompressed pubkeys not allowed in segwit context")
+            }
+        }
+    }
+}
+
+pub trait ScriptContext:
+    fmt::Debug + Clone + Ord + PartialOrd + Eq + PartialEq + private::Sealed
+{
+    /// Depending on ScriptContext, fragments can be malleable. For Example,
+    /// under Legacy context, PkH is malleable because it is possible to
+    /// estimate the cost of satisfaction because of compressed keys
+    /// This is currently only used in compiler code for removing malleable
+    /// compilations.
+    /// This does NOT recursively check if the children of the fragment are
+    /// valid or not. Since the compilation proceeds in a leaf to root fashion,
+    /// a recursive check is unnecessary.
+    fn check_frag_non_malleable<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        _frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError>;
+
+    /// Depending on script Context, some of the Terminals might not be valid.
+    /// For example, in Segwit Context with MiniscriptKey as bitcoin::PublicKey
+    /// uncompressed public keys are non-standard and thus invalid.
+    /// Post Tapscript upgrade, this would have to consider other nodes.
+    /// This does not recursively check
+    fn check_frag_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        _frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError>;
+}
+
+/// Legacy ScriptContext
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Legacy {}
+
+impl ScriptContext for Legacy {
+    fn check_frag_non_malleable<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        match *frag {
+            Terminal::PkH(ref _pkh) => Err(ScriptContextError::MalleablePkH),
+            Terminal::OrI(ref _a, ref _b) => Err(ScriptContextError::MalleableOrI),
+            Terminal::DupIf(ref _ms) => Err(ScriptContextError::MalleableDupIf),
+            _ => Ok(()),
+        }
+    }
+
+    fn check_frag_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        _frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
+}
+
+/// Segwitv0 ScriptContext
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Segwitv0 {}
+
+impl ScriptContext for Segwitv0 {
+    fn check_frag_non_malleable<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        _frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
+
+    fn check_frag_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        match *frag {
+            Terminal::PkK(ref pk) if pk.is_uncompressed() => {
+                Err(ScriptContextError::CompressedOnly)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Any ScriptContext. None of the checks should ever be invokde from
+/// under this context.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Any {}
+impl ScriptContext for Any {
+    fn check_frag_non_malleable<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        _frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        unreachable!()
+    }
+
+    fn check_frag_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        _frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        unreachable!()
+    }
+}
+
+impl Any {
+    pub(crate) fn from_legacy<Pk: MiniscriptKey>(
+        ms: &Miniscript<Pk, Legacy>,
+    ) -> &Miniscript<Pk, Any> {
+        // The fields Miniscript<Pk, Legacy> and Miniscript<Any, Legacy> only
+        // differ in PhantomData. This unsafe assumes that the unlerlying byte
+        // representation of the both should be the same. There is a Miri test
+        // checking the same.
+        unsafe {
+            use std::mem::transmute;
+            transmute::<&Miniscript<Pk, Legacy>, &Miniscript<Pk, Any>>(ms)
+        }
+    }
+
+    pub(crate) fn from_segwitv0<Pk: MiniscriptKey>(
+        ms: &Miniscript<Pk, Segwitv0>,
+    ) -> &Miniscript<Pk, Any> {
+        // The fields Miniscript<Pk, Legacy> and Miniscript<Any, Legacy> only
+        // differ in PhantomData. This unsafe assumes that the unlerlying byte
+        // representation of the both should be the same. There is a Miri test
+        // checking the same.
+        unsafe {
+            use std::mem::transmute;
+            transmute::<&Miniscript<Pk, Segwitv0>, &Miniscript<Pk, Any>>(ms)
+        }
+    }
+}
+
+/// Private Mod to prevent downstream from implementing this public trait
+mod private {
+    use super::{Any, Legacy, Segwitv0};
+
+    pub trait Sealed {}
+
+    // Implement for those same types, but no others.
+    impl Sealed for Legacy {}
+    impl Sealed for Segwitv0 {}
+    impl Sealed for Any {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Any, Legacy, Segwitv0};
+    use std::str::FromStr;
+
+    use {DummyKey, Miniscript};
+    type Segwitv0Script = Miniscript<DummyKey, Segwitv0>;
+    type LegacyScript = Miniscript<DummyKey, Legacy>;
+
+    //miri test for unsafe code
+    #[test]
+    fn any_unsafe_transmute_miri_test() {
+        let segwit_ms = Segwitv0Script::from_str("andor(pk(),or_i(and_v(vc:pk_h(),hash160(1111111111111111111111111111111111111111)),older(1008)),pk())").unwrap();
+        let legacy_ms = LegacyScript::from_str("andor(pk(),or_i(and_v(vc:pk_h(),hash160(1111111111111111111111111111111111111111)),older(1008)),pk())").unwrap();
+
+        let _any = Any::from_legacy(&legacy_ms);
+        let _any = Any::from_segwitv0(&segwit_ms);
+    }
+}

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -188,7 +188,7 @@ mod tests {
 
     //miri test for unsafe code
     #[test]
-    fn any_unsafe_transmute_miri_test() {
+    fn miri_test_context_transform() {
         let segwit_ms = Segwitv0Script::from_str("andor(pk(),or_i(and_v(vc:pk_h(),hash160(1111111111111111111111111111111111111111)),older(1008)),pk())").unwrap();
         let legacy_ms = LegacyScript::from_str("andor(pk(),or_i(and_v(vc:pk_h(),hash160(1111111111111111111111111111111111111111)),older(1008)),pk())").unwrap();
 

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -25,6 +25,7 @@ use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::{self, secp256k1};
 use {MiniscriptKey, ToPublicKey};
 
+use ScriptContext;
 use Terminal;
 
 /// Type alias for a signature/hashtype pair
@@ -510,8 +511,8 @@ impl Satisfaction {
     }
 
     /// Produce a satisfaction
-    pub fn satisfy<Pk: MiniscriptKey + ToPublicKey, Sat: Satisfier<Pk>>(
-        term: &Terminal<Pk>,
+    pub fn satisfy<Pk: MiniscriptKey + ToPublicKey, Ctx: ScriptContext, Sat: Satisfier<Pk>>(
+        term: &Terminal<Pk, Ctx>,
         stfr: &Sat,
     ) -> Self {
         match *term {
@@ -750,8 +751,8 @@ impl Satisfaction {
     }
 
     /// Produce a satisfaction
-    fn dissatisfy<Pk: MiniscriptKey + ToPublicKey, Sat: Satisfier<Pk>>(
-        term: &Terminal<Pk>,
+    fn dissatisfy<Pk: MiniscriptKey + ToPublicKey, Ctx: ScriptContext, Sat: Satisfier<Pk>>(
+        term: &Terminal<Pk, Ctx>,
         stfr: &Sat,
     ) -> Self {
         match *term {

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -1,7 +1,7 @@
 //! Other miscellaneous type properties which are not related to
 //! correctness or malleability.
 
-use super::{Error, ErrorKind, Property};
+use super::{Error, ErrorKind, Property, ScriptContext};
 use script_num_size;
 use std::cmp;
 use MiniscriptKey;
@@ -452,9 +452,13 @@ impl Property for ExtData {
 
     /// Compute the type of a fragment assuming all the children of
     /// Miniscript have been computed already.
-    fn type_check<Pk, C>(fragment: &Terminal<Pk>, _child: C) -> Result<Self, Error<Pk>>
+    fn type_check<Pk, Ctx, C>(
+        fragment: &Terminal<Pk, Ctx>,
+        _child: C,
+    ) -> Result<Self, Error<Pk, Ctx>>
     where
         C: FnMut(usize) -> Option<Self>,
+        Ctx: ScriptContext,
         Pk: MiniscriptKey,
     {
         let wrap_err = |result: Result<Self, ErrorKind>| {

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -9,27 +9,12 @@ use Terminal;
 
 pub const MAX_OPS_PER_SCRIPT: usize = 201;
 
-/// Whether a fragment is OK to be used in non-segwit scripts
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub enum LegacySafe {
-    /// The fragment can be used in pre-segwit contexts without concern
-    /// about malleability attacks/unbounded 3rd-party fee stuffing. This
-    /// means it has no `pk_h` constructions (cannot estimate public key
-    /// size from a hash) and no `d:`/`or_i` constructions (cannot control
-    /// the size of the switch input to `OP_IF`)
-    LegacySafe,
-    /// This fragment can only be safely used with Segwit
-    SegwitOnly,
-}
-
 /// Structure representing the extra type properties of a fragment which are
 /// relevant to legacy(pre-segwit) safety and fee estimation. If a fragment is
 /// used in pre-segwit transactions it will only be malleable but still is
 /// correct and sound.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct ExtData {
-    ///enum sorting whether the fragment is safe to be in used in pre-segwit context
-    pub legacy_safe: LegacySafe,
     /// The number of bytes needed to encode its scriptpubkey
     pub pk_cost: usize,
     /// Whether this fragment can be verify-wrapped for free
@@ -49,7 +34,6 @@ impl Property for ExtData {
 
     fn from_true() -> Self {
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: 1,
             has_verify_form: false,
             ops_count_static: 0,
@@ -60,7 +44,6 @@ impl Property for ExtData {
 
     fn from_false() -> Self {
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: 1,
             has_verify_form: false,
             ops_count_static: 0,
@@ -71,7 +54,6 @@ impl Property for ExtData {
 
     fn from_pk_k() -> Self {
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: 34,
             has_verify_form: false,
             ops_count_static: 0,
@@ -82,7 +64,6 @@ impl Property for ExtData {
 
     fn from_pk_h() -> Self {
         ExtData {
-            legacy_safe: LegacySafe::SegwitOnly,
             pk_cost: 24,
             has_verify_form: false,
             ops_count_static: 3,
@@ -99,7 +80,6 @@ impl Property for ExtData {
             (false, false) => 2,
         };
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: num_cost + 34 * n + 1,
             has_verify_form: true,
             ops_count_static: 1,
@@ -115,7 +95,6 @@ impl Property for ExtData {
 
     fn from_sha256() -> Self {
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: 33 + 6,
             has_verify_form: true,
             ops_count_static: 4,
@@ -126,7 +105,6 @@ impl Property for ExtData {
 
     fn from_hash256() -> Self {
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: 33 + 6,
             has_verify_form: true,
             ops_count_static: 4,
@@ -137,7 +115,6 @@ impl Property for ExtData {
 
     fn from_ripemd160() -> Self {
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: 21 + 6,
             has_verify_form: true,
             ops_count_static: 4,
@@ -148,7 +125,6 @@ impl Property for ExtData {
 
     fn from_hash160() -> Self {
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: 21 + 6,
             has_verify_form: true,
             ops_count_static: 4,
@@ -159,7 +135,6 @@ impl Property for ExtData {
 
     fn from_time(t: u32) -> Self {
         ExtData {
-            legacy_safe: LegacySafe::LegacySafe,
             pk_cost: script_num_size(t as usize) + 1,
             has_verify_form: false,
             ops_count_static: 1,
@@ -169,7 +144,6 @@ impl Property for ExtData {
     }
     fn cast_alt(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + 2,
             has_verify_form: false,
             ops_count_static: self.ops_count_static + 2,
@@ -180,7 +154,6 @@ impl Property for ExtData {
 
     fn cast_swap(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + 1,
             has_verify_form: self.has_verify_form,
             ops_count_static: self.ops_count_static + 1,
@@ -191,7 +164,6 @@ impl Property for ExtData {
 
     fn cast_check(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + 1,
             has_verify_form: true,
             ops_count_static: self.ops_count_static + 1,
@@ -202,7 +174,6 @@ impl Property for ExtData {
 
     fn cast_dupif(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: LegacySafe::SegwitOnly,
             pk_cost: self.pk_cost + 3,
             has_verify_form: false,
             ops_count_static: self.ops_count_static + 3,
@@ -214,7 +185,6 @@ impl Property for ExtData {
     fn cast_verify(self) -> Result<Self, ErrorKind> {
         let verify_cost = if self.has_verify_form { 0 } else { 1 };
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + if self.has_verify_form { 0 } else { 1 },
             has_verify_form: false,
             ops_count_static: self.ops_count_static + verify_cost,
@@ -225,7 +195,6 @@ impl Property for ExtData {
 
     fn cast_nonzero(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + 4,
             has_verify_form: false,
             ops_count_static: self.ops_count_static + 4,
@@ -236,7 +205,6 @@ impl Property for ExtData {
 
     fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + 1,
             has_verify_form: false,
             ops_count_static: self.ops_count_static + 1,
@@ -247,7 +215,6 @@ impl Property for ExtData {
 
     fn cast_true(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + 1,
             has_verify_form: false,
             ops_count_static: self.ops_count_static,
@@ -263,7 +230,6 @@ impl Property for ExtData {
 
     fn cast_unlikely(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + 4,
             has_verify_form: false,
             ops_count_static: self.ops_count_static + 3,
@@ -274,7 +240,6 @@ impl Property for ExtData {
 
     fn cast_likely(self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: self.legacy_safe,
             pk_cost: self.pk_cost + 4,
             has_verify_form: false,
             ops_count_static: self.ops_count_static + 3,
@@ -285,7 +250,6 @@ impl Property for ExtData {
 
     fn and_b(l: Self, r: Self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
             pk_cost: l.pk_cost + r.pk_cost + 1,
             has_verify_form: false,
             ops_count_static: l.ops_count_static + r.ops_count_static + 1,
@@ -300,7 +264,6 @@ impl Property for ExtData {
 
     fn and_v(l: Self, r: Self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
             pk_cost: l.pk_cost + r.pk_cost,
             has_verify_form: r.has_verify_form,
             ops_count_static: l.ops_count_static + r.ops_count_static,
@@ -311,7 +274,6 @@ impl Property for ExtData {
 
     fn or_b(l: Self, r: Self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
             pk_cost: l.pk_cost + r.pk_cost + 1,
             has_verify_form: false,
             ops_count_static: l.ops_count_static + r.ops_count_static + 1,
@@ -329,7 +291,6 @@ impl Property for ExtData {
 
     fn or_d(l: Self, r: Self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: LegacySafe::SegwitOnly,
             pk_cost: l.pk_cost + r.pk_cost + 3,
             has_verify_form: false,
             ops_count_static: l.ops_count_static + r.ops_count_static + 1,
@@ -346,7 +307,6 @@ impl Property for ExtData {
 
     fn or_c(l: Self, r: Self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
             pk_cost: l.pk_cost + r.pk_cost + 2,
             has_verify_form: false,
             ops_count_static: l.ops_count_static + r.ops_count_static + 2,
@@ -361,7 +321,6 @@ impl Property for ExtData {
 
     fn or_i(l: Self, r: Self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: legacy_safe2(l.legacy_safe, r.legacy_safe),
             pk_cost: l.pk_cost + r.pk_cost + 3,
             has_verify_form: false,
             ops_count_static: l.ops_count_static + r.ops_count_static + 3,
@@ -379,7 +338,6 @@ impl Property for ExtData {
 
     fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
-            legacy_safe: legacy_safe2(legacy_safe2(a.legacy_safe, b.legacy_safe), c.legacy_safe),
             pk_cost: a.pk_cost + b.pk_cost + c.pk_cost + 3,
             has_verify_form: false,
             ops_count_static: a.ops_count_static + b.ops_count_static + c.ops_count_static + 3,
@@ -400,7 +358,6 @@ impl Property for ExtData {
         S: FnMut(usize) -> Result<Self, ErrorKind>,
     {
         let mut pk_cost = 1 + script_num_size(k); //Equal and k
-        let mut legacy_safe = LegacySafe::LegacySafe;
         let mut ops_count_static = 0 as usize;
         let mut ops_count_sat_vec = Vec::with_capacity(n);
         let mut ops_count_nsat_sum = 0 as usize;
@@ -424,7 +381,6 @@ impl Property for ExtData {
                 }
                 _ => {}
             }
-            legacy_safe = legacy_safe2(legacy_safe, sub.legacy_safe);
         }
         let remaining_sat = k - sat_count;
         let mut sum: i32 = 0;
@@ -440,7 +396,6 @@ impl Property for ExtData {
                 .sum();
         }
         Ok(ExtData {
-            legacy_safe: legacy_safe,
             pk_cost: pk_cost + n - 1, //all pk cost + (n-1)*ADD
             has_verify_form: true,
             ops_count_static: ops_count_static + (n - 1) + 1, //adds and equal
@@ -580,12 +535,5 @@ impl Property for ExtData {
             ret.sanity_checks()
         }
         ret
-    }
-}
-
-fn legacy_safe2(a: LegacySafe, b: LegacySafe) -> LegacySafe {
-    match (a, b) {
-        (LegacySafe::LegacySafe, LegacySafe::LegacySafe) => LegacySafe::LegacySafe,
-        _ => LegacySafe::SegwitOnly,
     }
 }

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -22,6 +22,8 @@ use std::{error, fmt, str};
 use errstr;
 use expression::{self, FromTree};
 #[cfg(feature = "compiler")]
+use miniscript::ScriptContext;
+#[cfg(feature = "compiler")]
 use policy::compiler;
 #[cfg(feature = "compiler")]
 use policy::compiler::CompilerError;
@@ -102,7 +104,7 @@ impl fmt::Display for PolicyError {
 impl<Pk: MiniscriptKey> Policy<Pk> {
     /// Compile the descriptor into an optimized `Miniscript` representation
     #[cfg(feature = "compiler")]
-    pub fn compile(&self) -> Result<Miniscript<Pk>, CompilerError> {
+    pub fn compile<Ctx: ScriptContext>(&self) -> Result<Miniscript<Pk, Ctx>, CompilerError> {
         self.is_valid()?;
         match self.is_safe_nonmalleable() {
             (false, _) => Err(CompilerError::TopLevelNonSafe),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -28,7 +28,7 @@ pub mod concrete;
 pub mod semantic;
 
 use descriptor::Descriptor;
-use miniscript::Miniscript;
+use miniscript::{Miniscript, ScriptContext};
 use Terminal;
 
 pub use self::concrete::Policy as Concrete;
@@ -47,13 +47,13 @@ pub trait Liftable<Pk: MiniscriptKey> {
     fn lift(&self) -> Semantic<Pk>;
 }
 
-impl<Pk: MiniscriptKey> Liftable<Pk> for Miniscript<Pk> {
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Miniscript<Pk, Ctx> {
     fn lift(&self) -> Semantic<Pk> {
         self.as_inner().lift()
     }
 }
 
-impl<Pk: MiniscriptKey> Liftable<Pk> for Terminal<Pk> {
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
     fn lift(&self) -> Semantic<Pk> {
         match *self {
             Terminal::PkK(ref pk) => Semantic::KeyHash(pk.to_pubkeyhash()),
@@ -103,10 +103,8 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Terminal<Pk> {
 impl<Pk: MiniscriptKey> Liftable<Pk> for Descriptor<Pk> {
     fn lift(&self) -> Semantic<Pk> {
         match *self {
-            Descriptor::Bare(ref d)
-            | Descriptor::Sh(ref d)
-            | Descriptor::Wsh(ref d)
-            | Descriptor::ShWsh(ref d) => d.node.lift(),
+            Descriptor::Bare(ref d) | Descriptor::Sh(ref d) => d.node.lift(),
+            Descriptor::Wsh(ref d) | Descriptor::ShWsh(ref d) => d.node.lift(),
             Descriptor::Pk(ref p)
             | Descriptor::Pkh(ref p)
             | Descriptor::Wpkh(ref p)


### PR DESCRIPTION
Adds context to Miniscript. I have made a bunch of design decisions here with minor changes in API for satisfied constraints. 

I could not find a clean way to enforce constraints for the only bitcoin::PublicKey type because our code was generic, so had to hack in `IS_BITCOIN_PUBKEY` to the Miniscript Trait. 

This builds on top of #95 , would rebase and squash as needed. 
