### PR TITLE
Final fuzz fixes

### DIFF
--- a/fuzz/fuzz_targets/roundtrip_descriptor.rs
+++ b/fuzz/fuzz_targets/roundtrip_descriptor.rs
@@ -1,15 +1,23 @@
 
 extern crate miniscript;
+extern crate regex;
 
 use miniscript::{Descriptor, DummyKey};
-
+use regex::Regex;
 use std::str::FromStr;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
     if let Ok(desc) = Descriptor::<DummyKey>::from_str(&s) {
         let output = desc.to_string();
-        let normalize_aliases = s.replace("c:pk_k(", "pk(");
+        
+        let multi_wrap_pk_re = Regex::new("([a-z]+)c:pk_k\\(").unwrap();
+        let multi_wrap_pkh_re = Regex::new("([a-z]+)c:pk_h\\(").unwrap();
+
+        let normalize_aliases = multi_wrap_pk_re.replace_all(&s, "$1:pk(");
+        let normalize_aliases = multi_wrap_pkh_re.replace_all(&normalize_aliases, "$1:pkh(");
+        let normalize_aliases = normalize_aliases.replace("c:pk_k(", "pk(").replace("c:pk_h(", "pkh(");
+
         assert_eq!(normalize_aliases, output);
     }
 }

--- a/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
@@ -1,7 +1,9 @@
 
 extern crate miniscript;
+extern crate regex;
 
 use std::str::FromStr;
+use regex::Regex;
 
 use miniscript::{DummyKey};
 use miniscript::Miniscript;
@@ -10,7 +12,16 @@ fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
     if let Ok(desc) = Miniscript::<DummyKey>::from_str(&s) {
         let output = desc.to_string();
-        assert_eq!(s, output);
+        
+        let multi_wrap_pk_re = Regex::new("([a-z]+)c:pk_k\\(").unwrap();
+        let multi_wrap_pkh_re = Regex::new("([a-z]+)c:pk_h\\(").unwrap();
+
+        let normalize_aliases = multi_wrap_pk_re.replace_all(&s, "$1:pk(");
+        let normalize_aliases = multi_wrap_pkh_re.replace_all(&normalize_aliases, "$1:pkh(");
+        let normalize_aliases = normalize_aliases.replace("c:pk_k(", "pk(").replace("c:pk_h(", "pkh(");
+
+        assert_eq!(normalize_aliases, output);
+
     }
 }
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -561,6 +561,7 @@ mod tests {
         StdDescriptor::from_str("(x()").unwrap_err();
         StdDescriptor::from_str("(\u{7f}()3").unwrap_err();
         StdDescriptor::from_str("pk()").unwrap_err();
+        StdDescriptor::from_str("nl:0").unwrap_err(); //issue 63
 
         StdDescriptor::from_str(TEST_PK).unwrap();
     }


### PR DESCRIPTION
The last of fuzz fixes. We had to rely on regex for checking roundtrips for miniscript and descriptors after changes from #81 