### PR TITLE
Decode 65 bytes pubkey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,7 +333,7 @@ pub enum Error {
     IncorrectScriptHash,
     /// Recursion depth exceeded when parsing policy/miniscript from string
     MaxRecursiveDepthExceeded,
-    /// Recursion depth exceeded when parsing policy/miniscript from string
+    /// Script size too large
     ScriptSizeTooLarge,
 }
 

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -224,7 +224,7 @@ pub fn lex(script: &script::Script) -> Result<Vec<Token>, Error> {
                         x.copy_from_slice(bytes);
                         ret.push(Token::Hash32(x))
                     }
-                    33 => {
+                    33 | 65 => {
                         ret.push(Token::Pubkey(
                             PublicKey::from_slice(bytes).map_err(Error::BadPubkey)?,
                         ));

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -129,7 +129,9 @@ impl Miniscript<bitcoin::PublicKey> {
     /// Attempt to parse a script into a Miniscript representation
     pub fn parse(script: &script::Script) -> Result<Miniscript<bitcoin::PublicKey>, Error> {
         // Transactions more than 100Kb are non-standard
-        if script.len() > 10000 {}
+        if script.len() > 100_000 {
+            return Err(Error::ScriptSizeTooLarge);
+        }
         let tokens = lex(script)?;
         let mut iter = TokenIter::new(tokens);
 


### PR DESCRIPTION
This PR has two commits:

1. Decoding bug fix for 65-byte pubkey
2. Changing valid script size form 10k to 100kb as point out correctly in https://github.com/apoelstra/rust-miniscript/pull/101#discussion_r446829741