### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 1.0.0 - July 6, 2020
+
+- Added the following aliases to miniscript for ease of operations 
+	- Rename `pk` to `pk_k`
+	- Rename `thresh_m` to `multi`
+	- Add alias `pk(K)` = `c:pk_k(K)`
+	- Add alias `pkh(K)` = `c:pk_h(K)`
+- Fixed Miniscript parser bugs when decoding Hashlocks
+- Added scriptContext(`Legacy` and `Segwitv0`) to Miniscript. 
+- Miscellenous fixes against DoS attacks for heavy nesting.
+- Fixed Satisfier bug that caused flipping of arguments for `and_v` and `and_n` and `and_or`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miniscript"
-version = "0.12.0"
-authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+version = "1.0.0"
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 repository = "https://github.com/apoelstra/miniscript"
 description = "Miniscript: a subset of Bitcoin Script designed for analysis"
 license = "CC0-1.0"

--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ active development and is not held to the same standards as `rust-bitcoin` or
 For this reason, it is not recommended to use it in production.
 
 
+# Release Notes
+
+See [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
Release 1.0.0
Added Changelog, Readme. 

- ba02e75 Fix parser for issue #63
- 4df9d76 Removed Legacy enum from types
- cac1a26 Added Miri tests on travis
- c93bdef Added ScriptContext to Miniscript
- bcbe365 decode 65 bytes pubkeys too
- 0576765 Change limit to 100kb
- 824fed2 Flip argument order of Witness::combine for and_v and and_b
- 6438f10 Improve Miniscript robustness
- f556fd6 Case Sensitve Fuzz fixes
- 475f6a5 PkH aliases
- 1d6f4e9 Upstream fixup, .gitignore
- f2c98a3 Final fuzz fixes
- 4374578 Miniscript Root Level Check for Descriptors
- b0c6452 Policy fixes
- ff9373a And or fragments must have exactly two arguments
- 71a52f0 fmt fixes
- e40e012 removed redundant roundtrip_policy
- 63c895c suppressed and fixed warnings
- 835a7a7 fixed benches
- 7fe3466 Added unit tests from fuzz repo
- 351576a Updated fuzz tests
- 8a6ea10 removed duplicate fuzz tests
- 9619d7c wqFixed pk_k bug, added test
- cc7459c Fix fuzz crashes (fixes #89)
- 0bb8457 Add clarification on 2015 edition usage
- 89bf5b4 Add alias pk(K) = c:pk_k(K)
- 4d02fea Change string "pk" -> "pk_k"
- 9d8ce52 Rename `from_pk()` -> `from_pk_k()`
- c7a2bf6 Rename Terminal::Pk -> Terminal::PkK
- 3dac01d Rename `thresh_m` to `multi`
- 53fd7b3 compiler.rs: Replace `best_e` and `best_w` function with `best_fragment` function to avoid code duplication
- 2b38374 compiler.rs: Use shorthand notation
- fd361f6 compiler.rs: Define PolicyCache<Pk> type
- 1019be4 Fix `cargo fmt --all -- --check` error
- 3eebfd4 Fix issue 67
- f96c872 Cure RAS Syndrome
- 8d9faef Add examples to Travis runs
- 2eb7719 Give thresh weight estimation example with breakdown- 